### PR TITLE
Improved support for OSD functions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build*/
+debug*/
 bin
 obj
 *.depend

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ compile_commands.json
 .vscode
 CMakeFiles
 CMakeCache.txt
+vcpkg/

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -59,6 +59,10 @@ set(SOURCES_QT_SDL
 
     # rawinput/rawinput_common.c
     # RawInputThread.cpp
+
+    ScreenPrimeOSD.cpp
+    ScreenPrimeOSD.h
+
 )
 
 if (APPLE)

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -1465,6 +1465,22 @@ void EmuThread::run()
 
         NDS->SetKeyMask(Input::GetInputMask());
 
+        PrimeOSD::Canvas* OSD = mainWindow->panel->OSDCanvas;
+        QImage* Top_buffer = OSD[0].CanvasBuffer;
+        QPainter* Top_paint = OSD[0].Painter;
+        QImage* Bott_buffer = OSD[1].CanvasBuffer;
+        QPainter* Bott_paint = OSD[1].Painter;
+        
+        Top_buffer->fill(0x00000000);
+        Bott_buffer->fill(0x00000000);
+
+        if (drawVCur) {
+            Bott_paint->setPen(Qt::white);
+            Bott_paint->drawEllipse(virtualStylusX,virtualStylusY,11,11);
+        }
+
+        /*
+
         // Showing Virtual Stylus
         if (screenGL) {
             // OpenGL
@@ -1509,7 +1525,7 @@ void EmuThread::run()
                 }
             }
         }
-
+        */
         frameAdvanceOnce();
 
     } // End of while (EmuRunning != emuStatus_Exit)

--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -1465,67 +1465,24 @@ void EmuThread::run()
 
         NDS->SetKeyMask(Input::GetInputMask());
 
+        //MelonPrime OSD stuff
+
         PrimeOSD::Canvas* OSD = mainWindow->panel->OSDCanvas;
         QImage* Top_buffer = OSD[0].CanvasBuffer;
         QPainter* Top_paint = OSD[0].Painter;
         QImage* Bott_buffer = OSD[1].CanvasBuffer;
         QPainter* Bott_paint = OSD[1].Painter;
         
+        //Clear OSD buffers
         Top_buffer->fill(0x00000000);
         Bott_buffer->fill(0x00000000);
 
+        //Draw Vcurs
         if (drawVCur) {
             Bott_paint->setPen(Qt::white);
-            Bott_paint->drawEllipse(virtualStylusX,virtualStylusY,11,11);
+            Bott_paint->drawEllipse(virtualStylusX-5,virtualStylusY-5,10,10);
         }
 
-        /*
-
-        // Showing Virtual Stylus
-        if (screenGL) {
-            // OpenGL
-            screenGL->virtualCursorShow = drawVCur;
-            screenGL->virtualCursorX = virtualStylusX;
-            screenGL->virtualCursorY = virtualStylusY;
-
-        } else if (drawVCur) {
-            // no OpenGL
-            
-            // TODO Fix that drawVCur is not working with limited Framerate
-            // TODO If OpenGL is not used, Virtual Stylus is only visible when the frame rate limit is removed.
-
-            const int cursorSize = virtualCursorSize;
-            const int cursorOffset = virtualCursorSize / 2;
-
-            auto setPixel {
-                [&](int x, int y, melonDS::u32 color) {
-                    if (x < 0) return;
-                    if (x > 255) return;
-                    if (y < 0) return;
-                    if (y > 191) return;
-                    if (NDS->GPU.GPU3D.IsRendererAccelerated()) {
-                        NDS->GPU.Framebuffer[0][1][y * (256 * 3 + 1) + x] = color;
-                        NDS->GPU.Framebuffer[1][1][y * (256 * 3 + 1) + x] = color;
-                    } else {
-                        NDS->GPU.Framebuffer[0][1][y * 256 + x] = color;
-                        NDS->GPU.Framebuffer[1][1][y * 256 + x] = color;
-                    }
-                }
-            };
-
-            for (int y = 0; y < cursorSize; y++) {
-                for (int x = 0; x < cursorSize; x++) {
-                    int value = virtualCursorPixels[y * cursorSize + x];
-                    if (!value) continue;
-                    setPixel(
-                        virtualStylusX + x - cursorOffset,
-                        virtualStylusY + y - cursorOffset,
-                        0xFFFFFFFF
-                    );
-                }
-            }
-        }
-        */
         frameAdvanceOnce();
 
     } // End of while (EmuRunning != emuStatus_Exit)

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -581,7 +581,7 @@ void ScreenPanel::osdAddMessage(unsigned int color, const char* text)
 }
 
 void ScreenPanel::osdUpdate()
-{
+{    
     osdMutex.lock();
 
     qint64 tick_now = QDateTime::currentMSecsSinceEpoch();
@@ -666,6 +666,7 @@ void ScreenPanelNative::paintEvent(QPaintEvent* event)
         emuThread->FrontBufferLock.unlock();
 
         QRect screenrc(0, 0, 256, 192);
+        painter.setCompositionMode(QPainter::CompositionMode_SourceOver);
 
         for (int i = 0; i < numScreens; i++)
         {
@@ -903,7 +904,6 @@ void ScreenPanelGL::initOpenGL()
             256,192,0,
             GL_RGBA, GL_UNSIGNED_BYTE,OSDCanvas[i].CanvasBuffer->bits()
         );
-        printf("TextureLoaded:%i",OSDCanvas[i].GLTexture);
     }
 
 

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -621,8 +621,8 @@ ScreenPanelNative::ScreenPanelNative(QWidget* parent) : ScreenPanel(parent)
     screenTrans[1].reset();
 
     //MelonPrime OSD
-    OSDCanvas[0] = new PrimeOSD::Canvas(256, 192);
-    OSDCanvas[1] = new PrimeOSD::Canvas(256, 192);
+    OSDCanvas[0] = PrimeOSD::Canvas(256, 192);
+    OSDCanvas[1] = PrimeOSD::Canvas(256, 192);
 
 }
 
@@ -673,7 +673,7 @@ void ScreenPanelNative::paintEvent(QPaintEvent* event)
             painter.drawImage(screenrc, screen[screenKind[i]]);
 
             //MellonPrimeOSD
-            painter.drawImage(screenrc, OSDCanvas[screenKind[i]]->CanvasBuffer);
+            painter.drawImage(screenrc, *OSDCanvas[screenKind[i]].CanvasBuffer);
 
         }
     }

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -999,7 +999,7 @@ void ScreenPanelGL::drawScreenGL()
 
     for (int i = 0; i < numScreens; i++)
     {
-        glUniformMatrix2x3fv(screenShaderTransformULoc, 1, GL_TRUE, screenMatrix[screenKind[i]]);
+        glUniformMatrix2x3fv(screenShaderTransformULoc, 1, GL_TRUE, screenMatrix[i]);
         glDrawArrays(GL_TRIANGLES, screenKind[i] == 0 ? 0 : 2*3, 2*3);
     }
 

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -92,6 +92,8 @@ void ScreenPanel::setupScreenLayout()
     int w = width();
     int h = height();
 
+    PrimeCanvas = new OSD_Canvas(0,0,w,h);
+
     int sizing = Config::ScreenSizing;
     if (sizing == 3) sizing = autoScreenSizing;
 
@@ -668,6 +670,10 @@ void ScreenPanelNative::paintEvent(QPaintEvent* event)
             painter.drawImage(screenrc, screen[screenKind[i]]);
         }
     }
+
+    
+    //MellonPrimeOSD Stuff
+    painter.drawImage(PrimeCanvas->x,PrimeCanvas->y,*PrimeCanvas->CanvasBuffer);
 
     osdUpdate();
     if (osdEnabled)

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -92,8 +92,6 @@ void ScreenPanel::setupScreenLayout()
     int w = width();
     int h = height();
 
-    PrimeCanvas = new OSD_Canvas(0,0,w,h);
-
     int sizing = Config::ScreenSizing;
     if (sizing == 3) sizing = autoScreenSizing;
 
@@ -621,6 +619,11 @@ ScreenPanelNative::ScreenPanelNative(QWidget* parent) : ScreenPanel(parent)
 
     screenTrans[0].reset();
     screenTrans[1].reset();
+
+    //MelonPrime OSD
+    OSDCanvas[0] = new PrimeOSD::Canvas(256, 192);
+    OSDCanvas[1] = new PrimeOSD::Canvas(256, 192);
+
 }
 
 ScreenPanelNative::~ScreenPanelNative()
@@ -668,12 +671,12 @@ void ScreenPanelNative::paintEvent(QPaintEvent* event)
         {
             painter.setTransform(screenTrans[i]);
             painter.drawImage(screenrc, screen[screenKind[i]]);
+
+            //MellonPrimeOSD
+            painter.drawImage(screenrc, OSDCanvas[screenKind[i]]->CanvasBuffer);
+
         }
     }
-
-    
-    //MellonPrimeOSD Stuff
-    painter.drawImage(PrimeCanvas->x,PrimeCanvas->y,*PrimeCanvas->CanvasBuffer);
 
     osdUpdate();
     if (osdEnabled)

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -58,7 +58,7 @@ public:
     explicit ScreenPanel(QWidget* parent);
     virtual ~ScreenPanel();
 
-    PrimeOSD::Canvas* OSDCanvas[2];
+    PrimeOSD::Canvas OSDCanvas[2];
     
     // QTimer* setupMouseTimer();
     // void updateMouseTimer();

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -58,8 +58,8 @@ public:
     explicit ScreenPanel(QWidget* parent);
     virtual ~ScreenPanel();
 
-    OSD_Canvas* PrimeCanvas;
-
+    PrimeOSD::Canvas* OSDCanvas[2];
+    
     // QTimer* setupMouseTimer();
     // void updateMouseTimer();
     // QTimer* mouseTimer;

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -59,7 +59,8 @@ public:
     virtual ~ScreenPanel();
 
     PrimeOSD::Canvas OSDCanvas[2];
-    
+    uint OSDtextures[3];
+
     // QTimer* setupMouseTimer();
     // void updateMouseTimer();
     // QTimer* mouseTimer;

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -33,6 +33,7 @@
 #include "glad/glad.h"
 #include "FrontendUtil.h"
 #include "duckstation/gl/context.h"
+#include "ScreenPrimeOSD.h"
 
 
 class EmuThread;
@@ -56,6 +57,8 @@ class ScreenPanel : public QWidget
 public:
     explicit ScreenPanel(QWidget* parent);
     virtual ~ScreenPanel();
+
+    OSD_Canvas* PrimeCanvas;
 
     // QTimer* setupMouseTimer();
     // void updateMouseTimer();

--- a/src/frontend/qt_sdl/ScreenPrimeOSD.cpp
+++ b/src/frontend/qt_sdl/ScreenPrimeOSD.cpp
@@ -8,13 +8,16 @@ namespace PrimeOSD
 
 Canvas::Canvas(int w, int h)
 {
-    this->CanvasBuffer = QImage(w,h,QImage::Format_ARGB32_Premultiplied);
-    CanvasBuffer.fill(0x00000000);
-    this->Painter = new QPainter(&CanvasBuffer);
+    this->CanvasBuffer = new QImage(w,h,QImage::Format_ARGB32_Premultiplied);
+    CanvasBuffer->fill(0x00000000);
+    this->Painter = new QPainter(CanvasBuffer);
 }
 
-
-
+Canvas::Canvas(){
+    this->CanvasBuffer = new QImage(256, 192,QImage::Format_ARGB32_Premultiplied);
+    CanvasBuffer->fill(0x00000000);
+    this->Painter = new QPainter(CanvasBuffer);
+}
 
 
 }

--- a/src/frontend/qt_sdl/ScreenPrimeOSD.cpp
+++ b/src/frontend/qt_sdl/ScreenPrimeOSD.cpp
@@ -1,0 +1,10 @@
+#include "ScreenPrimeOSD.h"
+
+OSD_Canvas::OSD_Canvas(int x, int y, int w, int h)
+{
+    this->CanvasBuffer = new QImage(w,h,QImage::Format_ARGB32_Premultiplied);
+    CanvasBuffer->fill(0x00000000);
+    this->x = x;
+    this->y = y;
+    this->Painter = new QPainter(CanvasBuffer); 
+}

--- a/src/frontend/qt_sdl/ScreenPrimeOSD.cpp
+++ b/src/frontend/qt_sdl/ScreenPrimeOSD.cpp
@@ -1,10 +1,20 @@
 #include "ScreenPrimeOSD.h"
 
-OSD_Canvas::OSD_Canvas(int x, int y, int w, int h)
+#include <vector>
+
+
+namespace PrimeOSD
 {
-    this->CanvasBuffer = new QImage(w,h,QImage::Format_ARGB32_Premultiplied);
-    CanvasBuffer->fill(0x00000000);
-    this->x = x;
-    this->y = y;
-    this->Painter = new QPainter(CanvasBuffer); 
+
+Canvas::Canvas(int w, int h)
+{
+    this->CanvasBuffer = QImage(w,h,QImage::Format_ARGB32_Premultiplied);
+    CanvasBuffer.fill(0x00000000);
+    this->Painter = new QPainter(&CanvasBuffer);
+}
+
+
+
+
+
 }

--- a/src/frontend/qt_sdl/ScreenPrimeOSD.h
+++ b/src/frontend/qt_sdl/ScreenPrimeOSD.h
@@ -11,7 +11,6 @@ struct Canvas
 {
     QImage* CanvasBuffer;
     QPainter* Painter;
-    uint GLTexture;
     Canvas(int w,int h);
     Canvas();
 };

--- a/src/frontend/qt_sdl/ScreenPrimeOSD.h
+++ b/src/frontend/qt_sdl/ScreenPrimeOSD.h
@@ -9,9 +9,10 @@ namespace PrimeOSD
 
 struct Canvas
 {
-    QImage CanvasBuffer;
+    QImage* CanvasBuffer;
     QPainter* Painter;
     Canvas(int w,int h);
+    Canvas();
 };
 
 }

--- a/src/frontend/qt_sdl/ScreenPrimeOSD.h
+++ b/src/frontend/qt_sdl/ScreenPrimeOSD.h
@@ -1,0 +1,11 @@
+#include <QImage>
+#include <QPainter>
+
+struct OSD_Canvas
+{
+    int x;
+    int y;
+    QImage* CanvasBuffer;
+    QPainter* Painter;
+    OSD_Canvas(int x,int y, int w,int h);
+};

--- a/src/frontend/qt_sdl/ScreenPrimeOSD.h
+++ b/src/frontend/qt_sdl/ScreenPrimeOSD.h
@@ -1,11 +1,18 @@
 #include <QImage>
 #include <QPainter>
+#include <vector>
 
-struct OSD_Canvas
+
+
+namespace PrimeOSD
 {
-    int x;
-    int y;
-    QImage* CanvasBuffer;
+
+struct Canvas
+{
+    QImage CanvasBuffer;
     QPainter* Painter;
-    OSD_Canvas(int x,int y, int w,int h);
+    Canvas(int w,int h);
 };
+
+}
+

--- a/src/frontend/qt_sdl/ScreenPrimeOSD.h
+++ b/src/frontend/qt_sdl/ScreenPrimeOSD.h
@@ -11,6 +11,7 @@ struct Canvas
 {
     QImage* CanvasBuffer;
     QPainter* Painter;
+    uint GLTexture;
     Canvas(int w,int h);
     Canvas();
 };

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -583,9 +583,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
         actInputConfig = menu->addAction("Other settings");
         connect(actInputConfig, &QAction::triggered, this, &MainWindow::onOpenMetroidOtherSettings);
 
-        actTestOSD = menu->addAction("Test OSD");
-        connect(actTestOSD, &QAction::triggered, this, &MainWindow::onOpenMetroidTest);
-
     }
     setMenuBar(menubar);
 
@@ -2111,24 +2108,4 @@ void MainWindow::onOpenMetroidOtherSettings()
     dlg->switchTabToMetroid();
 
     connect(dlg, &InputConfigDialog::finished, this, &MainWindow::onInputConfigFinished);
-}
-
-void MainWindow::onOpenMetroidTest()
-{
-    QImage* Top_buffer = panel->OSDCanvas[0].CanvasBuffer;
-    QPainter* Top_paint = panel->OSDCanvas[0].Painter;
-    QImage* Bott_buffer = panel->OSDCanvas[1].CanvasBuffer;
-    QPainter* Bott_paint = panel->OSDCanvas[1].Painter;
-
-    int random_color1 = std::rand()*256*256+std::rand();
-    int random_color2 = std::rand()*256*256+std::rand();
-
-    Top_buffer->fill(random_color1);
-    Top_paint->setPen(0xff000000);
-    Top_paint->drawText(50,50,"TOP: Hello World");
-
-    Bott_buffer->fill(random_color2);
-    Bott_paint->setPen(0xff000000);
-    Bott_paint->drawText(50,50,"BOTT: Hello World");
-
-}
+}f

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -2115,12 +2115,20 @@ void MainWindow::onOpenMetroidOtherSettings()
 
 void MainWindow::onOpenMetroidTest()
 {
-    QPainter* paint = panel->OSDCanvas[0]->Painter;
-    QImage buffer = panel->OSDCanvas[0]->CanvasBuffer;
+    QImage* Top_buffer = panel->OSDCanvas[0].CanvasBuffer;
+    QPainter* Top_paint = panel->OSDCanvas[0].Painter;
+    QImage* Bott_buffer = panel->OSDCanvas[1].CanvasBuffer;
+    QPainter* Bott_paint = panel->OSDCanvas[1].Painter;
 
-    int random_color = std::rand()*256*256+std::rand();
+    int random_color1 = std::rand()*256*256+std::rand();
+    int random_color2 = std::rand()*256*256+std::rand();
 
-    buffer.fill(random_color);
-    paint->setPen(0xff000000);
-    paint->drawText(50,50,"Hello World");
+    Top_buffer->fill(random_color1);
+    Top_paint->setPen(0xff000000);
+    Top_paint->drawText(50,50,"TOP: Hello World");
+
+    Bott_buffer->fill(random_color2);
+    Bott_paint->setPen(0xff000000);
+    Bott_paint->drawText(50,50,"BOTT: Hello World");
+
 }

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -582,6 +582,10 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
 
         actInputConfig = menu->addAction("Other settings");
         connect(actInputConfig, &QAction::triggered, this, &MainWindow::onOpenMetroidOtherSettings);
+
+        actTestOSD = menu->addAction("Test OSD");
+        connect(actTestOSD, &QAction::triggered, this, &MainWindow::onOpenMetroidTest);
+
     }
     setMenuBar(menubar);
 
@@ -2107,4 +2111,16 @@ void MainWindow::onOpenMetroidOtherSettings()
     dlg->switchTabToMetroid();
 
     connect(dlg, &InputConfigDialog::finished, this, &MainWindow::onInputConfigFinished);
+}
+
+void MainWindow::onOpenMetroidTest()
+{
+    QPainter* paint = panel->PrimeCanvas->Painter;
+    QImage* buffer = panel->PrimeCanvas->CanvasBuffer;
+
+    int random_color = std::rand()*256*256+std::rand();
+
+    buffer->fill(random_color);
+    paint->setPen(0xff000000);
+    paint->drawText(100,100,"Hello World");
 }

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -2115,12 +2115,12 @@ void MainWindow::onOpenMetroidOtherSettings()
 
 void MainWindow::onOpenMetroidTest()
 {
-    QPainter* paint = panel->PrimeCanvas->Painter;
-    QImage* buffer = panel->PrimeCanvas->CanvasBuffer;
+    QPainter* paint = panel->OSDCanvas[0]->Painter;
+    QImage buffer = panel->OSDCanvas[0]->CanvasBuffer;
 
     int random_color = std::rand()*256*256+std::rand();
 
-    buffer->fill(random_color);
+    buffer.fill(random_color);
     paint->setPen(0xff000000);
-    paint->drawText(100,100,"Hello World");
+    paint->drawText(50,50,"Hello World");
 }

--- a/src/frontend/qt_sdl/Window.cpp
+++ b/src/frontend/qt_sdl/Window.cpp
@@ -582,7 +582,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent)
 
         actInputConfig = menu->addAction("Other settings");
         connect(actInputConfig, &QAction::triggered, this, &MainWindow::onOpenMetroidOtherSettings);
-
     }
     setMenuBar(menubar);
 
@@ -2108,4 +2107,4 @@ void MainWindow::onOpenMetroidOtherSettings()
     dlg->switchTabToMetroid();
 
     connect(dlg, &InputConfigDialog::finished, this, &MainWindow::onInputConfigFinished);
-}f
+}

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -209,6 +209,7 @@ private slots:
 
     void onOpenMetroidInputSettings();
     void onOpenMetroidOtherSettings();
+    void onOpenMetroidTest();
 
 private:
     virtual void closeEvent(QCloseEvent* event) override;
@@ -263,6 +264,7 @@ public:
     QAction* actMPNewInstance;
 
     QAction* actEmuSettings;
+    QAction* actTestOSD;
 #ifdef __APPLE__
     QAction* actPreferences;
 #endif

--- a/src/frontend/qt_sdl/Window.h
+++ b/src/frontend/qt_sdl/Window.h
@@ -209,7 +209,6 @@ private slots:
 
     void onOpenMetroidInputSettings();
     void onOpenMetroidOtherSettings();
-    void onOpenMetroidTest();
 
 private:
     virtual void closeEvent(QCloseEvent* event) override;
@@ -264,7 +263,6 @@ public:
     QAction* actMPNewInstance;
 
     QAction* actEmuSettings;
-    QAction* actTestOSD;
 #ifdef __APPLE__
     QAction* actPreferences;
 #endif

--- a/src/frontend/qt_sdl/overlay_shaders.h
+++ b/src/frontend/qt_sdl/overlay_shaders.h
@@ -55,7 +55,7 @@ const inline char* kScreenFS_overlay = R"(#version 140
     }
 )";
 
-
+/*
 const inline int virtualCursorSize = 11;
 const inline bool virtualCursorPixels[] = {
     0,0,0,1,1,1,1,1,0,0,0,
@@ -70,7 +70,7 @@ const inline bool virtualCursorPixels[] = {
     0,0,1,0,0,0,0,0,1,0,0,
     0,0,0,1,1,1,1,1,0,0,0,
 };
-
+*/
 
 /*
 const inline int virtualCursorSize = 37;


### PR DESCRIPTION
This pull request adds support for on screen display functionality, via `QImage` and `QPainter` methods from Qt6.
This is accomplished by creating a `QImage` buffer for both the top and bottom screens, and then copying the buffer over each screen during the draw loop. 

This allows for simple graphics / UI elements to be drawn over either screen using `QPainter` method calls. 

Simple example of implementing the draw function for the virtual cursor:
(in this example I simply draw a circle using the draw shape tool, but this could easily be changed to copy a transparent texture.)  
![image](https://github.com/user-attachments/assets/e15bae58-3ae4-48e1-8f38-09b9524e193e)
![image](https://github.com/user-attachments/assets/68b67eb0-3872-4010-85b4-66a39b31bb94)

This will make implementing future UI elements much easier going forward. 