### PR TITLE
Resolution of Input Configuration Dialog Display Issues

### DIFF
--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -787,22 +787,35 @@ void EmuThread::run()
     bool enableAim = true;
     bool wasLastFrameFocused = false;
 
+    /**
+     * @brief Function to show or hide the cursor on MelonPrimeDS
+     *
+     * Controls the mouse cursor visibility state on MelonPrimeDS. Does nothing if
+     * the requested state is the same as the current state. When changing cursor
+     * visibility, uses Qt::QueuedConnection to safely execute on the UI thread.
+     *
+     * @param show true to show the cursor, false to hide it
+     */
     auto showCursorOnMelonPrimeDS = [&](bool show) {
+        // Do nothing if the requested state is the same as current state (optimization)
         if (show == isCursorVisible) return;
 
+        // Get and verify panel exists
         auto* panel = emuInstance->getMainWindow()->panel;
         if (!panel) return;
 
+        // Use Qt::QueuedConnection to safely execute on the UI thread
         QMetaObject::invokeMethod(panel,
             [panel, show]() {
+                // Set cursor visibility (normal ArrowCursor or invisible BlankCursor)
                 panel->setCursor(show ? Qt::ArrowCursor : Qt::BlankCursor);
             },
             Qt::ConnectionType::QueuedConnection
         );
 
+        // Record the state change
         isCursorVisible = show;
         };
-
 
 // #define STYLUS_MODE 1 // this is for stylus user
 
@@ -971,6 +984,8 @@ void EmuThread::run()
             (uint32_t(emuInstance->hotkeyDown(HK_MetroidMoveRight)) << 3);
 
         if (localCfg.GetBool("Metroid.Operation.SnapTap")) {
+            // SnapTap mode
+
             // Detect newly pressed keys
             uint32_t newlyPressed = currentInputBitmap & ~lastInputBitmap;
 

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.cpp
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.cpp
@@ -49,14 +49,19 @@ InputConfigDialog::InputConfigDialog(QWidget* parent) : QDialog(parent), ui(new 
     Config::Table keycfg = instcfg.GetTable("Keyboard");
     Config::Table joycfg = instcfg.GetTable("Joystick");
 
+    /*
+    * MelonPrimeDS remove DSKeypadTab
     for (int i = 0; i < keypad_num; i++)
     {
         const char* btn = EmuInstance::buttonNames[dskeyorder[i]];
         keypadKeyMap[i] = keycfg.GetInt(btn);
         keypadJoyMap[i] = joycfg.GetInt(btn);
     }
+    */
 
     int i = 0;
+    /*
+    * MelonPrimeDS remove SolarFunctionTab
     for (int hotkey : hk_addons)
     {
         const char* btn = EmuInstance::hotkeyNames[hotkey];
@@ -65,7 +70,9 @@ InputConfigDialog::InputConfigDialog(QWidget* parent) : QDialog(parent), ui(new 
         i++;
     }
 
+
     i = 0;
+        */
     for (int hotkey : hk_general)
     {
         const char* btn = EmuInstance::hotkeyNames[hotkey];
@@ -74,7 +81,11 @@ InputConfigDialog::InputConfigDialog(QWidget* parent) : QDialog(parent), ui(new 
         i++;
     }
 
+    /*
+    * MelonPrimeDS remove SolarFunctionTab
     populatePage(ui->tabAddons, hk_addons_labels, addonsKeyMap, addonsJoyMap);
+    */
+
     populatePage(ui->tabHotkeysGeneral, hk_general_labels, hkGeneralKeyMap, hkGeneralJoyMap);
 
     // MelonPrimeDS { // load Config
@@ -92,8 +103,18 @@ InputConfigDialog::InputConfigDialog(QWidget* parent) : QDialog(parent), ui(new 
         i++;
     }
 
+    i = 0;
+    for (int hotkey : hk_tabAddonsMetroid2)
+    {
+        const char* btn = EmuInstance::hotkeyNames[hotkey];
+        addonsMetroid2KeyMap[i] = keycfg.GetInt(btn);
+        addonsMetroid2JoyMap[i] = joycfg.GetInt(btn);
+        i++;
+    }
+
     // load labels
     populatePage(ui->tabAddonsMetroid, hk_tabAddonsMetroid_labels, addonsMetroidKeyMap, addonsMetroidJoyMap);
+    populatePage(ui->tabAddonsMetroid2, hk_tabAddonsMetroid2_labels, addonsMetroid2KeyMap, addonsMetroid2JoyMap);
 
     // Other Metroid Settings Tab
 
@@ -122,7 +143,7 @@ InputConfigDialog::InputConfigDialog(QWidget* parent) : QDialog(parent), ui(new 
         ui->cbxJoystick->setEnabled(false);
     }
 
-    setupKeypadPage();
+    // setupKeypadPage(); //MelonPrimeDS remove DSKeypadConfig
 
     int inst = emuInstance->getInstanceID();
     if (inst > 0)
@@ -136,8 +157,11 @@ InputConfigDialog::~InputConfigDialog()
     delete ui;
 }
 
+/*
+* MelonPrimeDS remove DSKeypadConfig
 void InputConfigDialog::setupKeypadPage()
 {
+    return;// MelonPrimeDS remove DSKeypadConfig
     for (int i = 0; i < keypad_num; i++)
     {
         QPushButton* pushButtonKey = this->findChild<QPushButton*>(QStringLiteral("btnKey") + dskeylabels[i]);
@@ -158,13 +182,15 @@ void InputConfigDialog::setupKeypadPage()
         }
     }
 }
+*/
 
 void InputConfigDialog::populatePage(QWidget* page,
     const std::initializer_list<const char*>& labels,
     int* keymap, int* joymap)
 {
     // kind of a hack
-    bool ishotkey = (page != ui->tabInput);
+    bool ishotkey = true; // MelonPrimeDS remove DSKeypadConfig
+        //(page != ui->tabInput); // MelonPrimeDS remove DSKeypadConfig
 
     QHBoxLayout* main_layout = new QHBoxLayout();
 
@@ -216,14 +242,20 @@ void InputConfigDialog::on_InputConfigDialog_accepted()
     Config::Table keycfg = instcfg.GetTable("Keyboard");
     Config::Table joycfg = instcfg.GetTable("Joystick");
 
+    /*
+    * MelonPrimeDS remove DSKeypadTab
     for (int i = 0; i < keypad_num; i++)
     {
         const char* btn = EmuInstance::buttonNames[dskeyorder[i]];
         keycfg.SetInt(btn, keypadKeyMap[i]);
         joycfg.SetInt(btn, keypadJoyMap[i]);
     }
+    */
+
 
     int i = 0;
+    /*
+    * MelonPrimeDS remove SolarFunctionTab
     for (int hotkey : hk_addons)
     {
         const char* btn = EmuInstance::hotkeyNames[hotkey];
@@ -232,7 +264,9 @@ void InputConfigDialog::on_InputConfigDialog_accepted()
         i++;
     }
 
+
     i = 0;
+        */
     for (int hotkey : hk_general)
     {
         const char* btn = EmuInstance::hotkeyNames[hotkey];
@@ -253,6 +287,16 @@ void InputConfigDialog::on_InputConfigDialog_accepted()
         joycfg.SetInt(btn, addonsMetroidJoyMap[i]);
         i++;
     }
+
+    i = 0;
+    for (int hotkey : hk_tabAddonsMetroid2)
+    {
+        const char* btn = EmuInstance::hotkeyNames[hotkey];
+        keycfg.SetInt(btn, addonsMetroid2KeyMap[i]);
+        joycfg.SetInt(btn, addonsMetroid2JoyMap[i]);
+        i++;
+    }
+
 
     // Sensitivities
     instcfg.SetInt("Metroid.Sensitivity.Aim", ui->metroidAimSensitvitySpinBox->value());
@@ -276,6 +320,8 @@ void InputConfigDialog::on_InputConfigDialog_rejected()
     closeDlg();
 }
 
+/*
+ * MelonPrimeDS remove DSKeypadConfig
 void InputConfigDialog::on_btnKeyMapSwitch_clicked()
 {
     ui->stackMapping->setCurrentIndex(0);
@@ -285,6 +331,7 @@ void InputConfigDialog::on_btnJoyMapSwitch_clicked()
 {
     ui->stackMapping->setCurrentIndex(1);
 }
+*/
 
 void InputConfigDialog::on_cbxJoystick_currentIndexChanged(int id)
 {

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.h
@@ -91,32 +91,22 @@ static constexpr std::initializer_list<int> hk_tabAddonsMetroid =
     HK_MetroidMoveBack,
     HK_MetroidMoveLeft,
     HK_MetroidMoveRight,
-    HK_MetroidJump,
-    HK_MetroidMorphBall,
-    HK_MetroidZoom,
-    HK_MetroidHoldMorphBallBoost,
-    HK_MetroidScanVisor,
-    HK_MetroidUILeft,
-    HK_MetroidUIRight,
-    HK_MetroidUIOk,
-    HK_MetroidUIYes,
-    HK_MetroidUINo,
     HK_MetroidShootScan,
     HK_MetroidScanShoot,
+    HK_MetroidZoom,
+    HK_MetroidJump,
+    HK_MetroidMorphBall,
+    HK_MetroidHoldMorphBallBoost,
     HK_MetroidWeaponBeam,
     HK_MetroidWeaponMissile,
-    HK_MetroidWeaponSpecial,
-    HK_MetroidWeaponNext,
-    HK_MetroidWeaponPrevious,
     HK_MetroidWeapon1,
     HK_MetroidWeapon2,
     HK_MetroidWeapon3,
     HK_MetroidWeapon4,
     HK_MetroidWeapon5,
     HK_MetroidWeapon6,
+    HK_MetroidWeaponSpecial,
     HK_MetroidMenu,
-    HK_MetroidIngameSensiUp,
-    HK_MetroidIngameSensiDown
 
 };
 
@@ -126,35 +116,57 @@ static constexpr std::initializer_list<const char*> hk_tabAddonsMetroid_labels =
     "[Metroid] (S) Move Back",
     "[Metroid] (A) Move Left",
     "[Metroid] (D) Move Right",
-    "[Metroid] (Space) Jump",
-    "[Metroid] (L. Ctrl) Transform",
-    "[Metroid] (Mouse Right) Imperialist Zoom, Map Zoom Out, Morph Ball Boost",
-    "[Metroid] (Shift) Hold to Fast Morph Ball Boost",
-    "[Metroid] (C) Scan Visor",
-    "[Metroid] (Z) UI Left (Adventure Left Arrow / Hunter License L)",
-    "[Metroid] (X) UI Right (Adventure Right Arrow / Hunter License R)",
-    "[Metroid] (F) UI Ok",
-    "[Metroid] (G) UI Yes (Enter Starship)",
-    "[Metroid] (H) UI No (Enter Starship)",
     "[Metroid] (Mouse Left) Shoot/Scan, Map Zoom In",
     "[Metroid] (V) Scan/Shoot, Map Zoom In",
+    "[Metroid] (Mouse Right) Imperialist Zoom, Map Zoom Out, Morph Ball Boost",
+    "[Metroid] (Space) Jump",
+    "[Metroid] (L. Ctrl) Transform",
+    "[Metroid] (Shift) Hold to Fast Morph Ball Boost",
     "[Metroid] (Mouse 5, Side Top) Weapon Beam",
     "[Metroid] (Mouse 4, Side Bottom) Weapon Missile",
-    "[Metroid] (R) SpecialWeapon (Last used Weapon, Omega cannon)",
-    "[Metroid] (J) Next Weapon in the sorted order",
-    "[Metroid] (K) Previous Weapon in the sorted order",
     "[Metroid] (1) Weapon 1",
     "[Metroid] (2) Weapon 2",
     "[Metroid] (3) Weapon 3",
     "[Metroid] (4) Weapon 4",
     "[Metroid] (5) Weapon 5",
     "[Metroid] (6) Weapon 6",
+    "[Metroid] (R) SpecialWeapon (Last used Weapon, Omega cannon)",
     "[Metroid] (Tab) Menu/Map",
-    "[Metroid] (PgUp) AimSensitivity Up",
-    "[Metroid] (PgDown) AimSensitivity Down"
 };
 
 static_assert(hk_tabAddonsMetroid.size() == hk_tabAddonsMetroid_labels.size());
+
+
+static constexpr std::initializer_list<int> hk_tabAddonsMetroid2 =
+{
+    HK_MetroidIngameSensiUp,
+    HK_MetroidIngameSensiDown,
+    HK_MetroidWeaponNext,
+    HK_MetroidWeaponPrevious,
+    HK_MetroidScanVisor,
+    HK_MetroidUILeft,
+    HK_MetroidUIRight,
+    HK_MetroidUIOk,
+    HK_MetroidUIYes,
+    HK_MetroidUINo,
+};
+
+static constexpr std::initializer_list<const char*> hk_tabAddonsMetroid2_labels =
+{
+
+    "[Metroid] (PgUp) AimSensitivity Up",
+    "[Metroid] (PgDown) AimSensitivity Down",
+    "[Metroid] (J) Next Weapon in the sorted order",
+    "[Metroid] (K) Previous Weapon in the sorted order",
+    "[Metroid] (C) Scan Visor",
+    "[Metroid] (Z) UI Left (Adventure Left Arrow / Hunter License L)",
+    "[Metroid] (X) UI Right (Adventure Right Arrow / Hunter License R)",
+    "[Metroid] (F) UI Ok",
+    "[Metroid] (G) UI Yes (Enter Starship)",
+    "[Metroid] (H) UI No (Enter Starship)",
+};
+
+static_assert(hk_tabAddonsMetroid2.size() == hk_tabAddonsMetroid2_labels.size());
 // } MelonPrimeDS
 
 
@@ -198,8 +210,11 @@ private slots:
     void on_InputConfigDialog_accepted();
     void on_InputConfigDialog_rejected();
 
+    /*
+    * MelonPrimeDS remove DSKeypadConfig
     void on_btnKeyMapSwitch_clicked();
     void on_btnJoyMapSwitch_clicked();
+    */
     void on_cbxJoystick_currentIndexChanged(int id);
 
     /* MelonPrimeDS { */
@@ -216,7 +231,7 @@ private:
     void populatePage(QWidget* page,
         const std::initializer_list<const char*>& labels,
         int* keymap, int* joymap);
-    void setupKeypadPage();
+    // void setupKeypadPage(); // MelonPrimeDS remove DSKeypadConfig
 
     Ui::InputConfigDialog* ui;
 
@@ -225,6 +240,7 @@ private:
     int keypadKeyMap[12], keypadJoyMap[12];
     int addonsKeyMap[hk_addons.size()], addonsJoyMap[hk_addons.size()];
     int addonsMetroidKeyMap[hk_tabAddonsMetroid.size()], addonsMetroidJoyMap[hk_tabAddonsMetroid.size()]; // MelonPrimeDS
+    int addonsMetroid2KeyMap[hk_tabAddonsMetroid2.size()], addonsMetroid2JoyMap[hk_tabAddonsMetroid2.size()]; // MelonPrimeDS
     int hkGeneralKeyMap[hk_general.size()], hkGeneralJoyMap[hk_general.size()];
     int joystickID;
 };

--- a/src/frontend/qt_sdl/InputConfig/InputConfigDialog.ui
+++ b/src/frontend/qt_sdl/InputConfig/InputConfigDialog.ui
@@ -35,6 +35,8 @@
      <property name="currentIndex">
       <number>0</number>
      </property>
+	<!--
+	 MelonPrimeDS remove DSKeypadConfig
      <widget class="QWidget" name="tabInput">
       <attribute name="title">
        <string>DS keypad</string>
@@ -2267,11 +2269,16 @@
        </item>
       </layout>
      </widget>
+	  -->
+     <!--
+     MelonPrimeDS remove Solar Function tab 
      <widget class="QWidget" name="tabAddons">
       <attribute name="title">
        <string>Add-ons</string>
       </attribute>
      </widget>
+	  -->
+		
      <widget class="QWidget" name="tabHotkeysGeneral">
       <attribute name="title">
        <string>General hotkeys</string>
@@ -2285,6 +2292,13 @@
 			    <string>Add-ons (Metroid)</string>
 		    </attribute>
 	    </widget>
+
+		<!-- Tab Add-ons (Metroid)2 -->
+		<widget class="QWidget" name="tabAddonsMetroid2">
+			<attribute name="title">
+				<string>Add-ons (Metroid) 2</string>
+			</attribute>
+		</widget>
 
 		<!-- Tab Other Metroid settings -->
 	    <widget class="QWidget" name="tabMetroid">
@@ -2428,6 +2442,8 @@
    </item>
   </layout>
  </widget>
+<!--
+  MelonPrimeDS remove DSKeypadConfig
  <tabstops>
   <tabstop>tabWidget</tabstop>
   <tabstop>btnJoyMapSwitch</tabstop>
@@ -2458,6 +2474,8 @@
   <tabstop>btnJoyStart</tabstop>
   <tabstop>cbxJoystick</tabstop>
  </tabstops>
+ -->
+ 
  <resources>
   <include location="resources/ds.qrc"/>
  </resources>


### PR DESCRIPTION
Overview
Fixed an issue where users with smaller display areas couldn't properly configure settings in the InputConfigDialog due to the dialog being too large. Solution
Split the configuration interface into two separate tabs instead of displaying all items on a single tab. This change ensures proper functionality even on smaller displays.