### PR TITLE
fix CI: add vcpkg.json to CMake build dir cache key

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -91,7 +91,7 @@ jobs:
       uses: actions/cache@v4
       with:
         path: ${{ github.workspace }}/build
-        key: ${{ runner.os }}-cmake-build-${{ hashFiles('CMakeLists.txt', 'src/**', 'include/**', 'cmake/**', 'CMakePresets.json') }}
+        key: ${{ runner.os }}-cmake-build-${{ hashFiles('CMakeLists.txt', 'src/**', 'include/**', 'cmake/**', 'CMakePresets.json', 'vcpkg.json') }}
         restore-keys: |
           ${{ runner.os }}-cmake-build-${{ hashFiles('CMakeLists.txt') }}
           ${{ runner.os }}-cmake-build-


### PR DESCRIPTION
vcpkg.json was missing from the cmake-build cache key, so upgrading the vcpkg baseline left the old vcpkg_installed in the restored build dir. Configure skipped vcpkg install and the build failed with missing libzlib.a.