### PR TITLE
Fix Morph Ball Boost: R button boost works after transform, aim boost…

### DIFF
--- a/src/frontend/qt_sdl/MelonPrime.cpp
+++ b/src/frontend/qt_sdl/MelonPrime.cpp
@@ -806,6 +806,7 @@ namespace MelonPrime {
         m_ptrs.doubleDamageTimer = GetRamPointer<uint16_t>(mainRAM, m_currentRom.playerDoubleDamageTimer + offP);
         // Weavel-only effective HP — these are read every frame but only consulted
         // when BIT_IS_WEAVEL is set, so resolving them unconditionally is fine.
+        m_ptrs.flags1         = GetRamPointer<uint32_t>(mainRAM, playerBase + 0x4C4u);
         m_ptrs.moreFlags      = GetRamPointer<uint32_t>(mainRAM, playerBase + 0x4C8u);
         m_ptrs.weavelProxyPtr = GetRamPointer<uint32_t>(mainRAM, playerBase + 0xF24u);
         m_damageNotifyPurpleState = {};

--- a/src/frontend/qt_sdl/MelonPrime.h
+++ b/src/frontend/qt_sdl/MelonPrime.h
@@ -139,6 +139,7 @@ namespace MelonPrime {
         // Weavel proxy: only read when BIT_IS_WEAVEL is set. When the alt-form
         // proxy is active, observed HP = mainHp + proxyHp (avoids false notify
         // on transform HP-split).
+        uint32_t* flags1;          // CPlayer +0x4C4, bit26 = Boosting, bit27 = CanTouchBoost
         uint32_t* moreFlags;       // CPlayer +0x4C8, bit5 = proxy active
         uint32_t* weavelProxyPtr;  // CPlayer +0xF24, ARM9 pointer to proxy entity
     };

--- a/src/frontend/qt_sdl/MelonPrimeGameInput.cpp
+++ b/src/frontend/qt_sdl/MelonPrimeGameInput.cpp
@@ -303,6 +303,24 @@ namespace MelonPrime {
 
     HOT_FUNCTION void MelonPrimeCore::ApplyZoomBindingInput()
     {
+        // In Morph Ball / Alt Form the R input drives Morph Ball Boost, not zoom
+        // (zoom does not exist in alt form). The game reads the boost binding
+        // (player+0x3B4 = R in the standard presets), so always press the legacy
+        // R bit here and bypass the newer zoom methods. The native zoom toggle
+        // would otherwise just flip scope state, and the new-method remap would
+        // press the zoom binding instead of R — both left R unpressed in alt
+        // form, so pressing and releasing R after transforming produced no boost.
+        if (IsPlayerAltForm()) {
+            // Keep the native-toggle press edge in sync so leaving alt form mid
+            // hold does not fire a stale toggle on the next biped frame.
+            if (m_enableNativeZoomToggle)
+                m_nativeZoomTogglePrevDown = IsDown(IB_ZOOM);
+
+            if (IsDown(IB_ZOOM))
+                m_inputMaskFast = static_cast<uint16_t>(m_inputMaskFast & ~(1u << INPUT_R));
+            return;
+        }
+
         if (m_enableNativeZoomToggle) {
             UpdateNativeZoomToggleInput();
             return;

--- a/src/frontend/qt_sdl/MelonPrimeInGame.cpp
+++ b/src/frontend/qt_sdl/MelonPrimeInGame.cpp
@@ -242,21 +242,41 @@ namespace MelonPrime {
 
     HOT_FUNCTION bool MelonPrimeCore::HandleMorphBallBoost()
     {
-        // P-36: Combined early exit — skip both samus check AND boost-down check
-        // in a single branch. ~70%+ of frames hit this (non-Samus or no boost key).
-        // Original had nested if/else with the aimBlock cleanup duplicated in the
-        // else branch; now the common fast path (no boost) is a single LIKELY test.
-        if (LIKELY(!m_flags.test(StateFlags::BIT_IS_SAMUS) || !IsDown(IB_MORPH_BOOST))) {
-            // Guard redundant store - 99%+ of frames this bit is already 0.
-            if (UNLIKELY(m_aimBlockBits & AIMBLK_MORPHBALL_BOOST)) {
-                SetAimBlockBranchless(AIMBLK_MORPHBALL_BOOST, false);
-            }
+        // Boost is Samus-only; bail for every other hunter on the cheapest check.
+        if (LIKELY(!m_flags.test(StateFlags::BIT_IS_SAMUS))) {
             return false;
         }
 
-        // Samus + boost key held — full logic (rare path)
         const bool isAltForm = (*m_ptrs.isAltForm) == 0x02;
         m_flags.assign(StateFlags::BIT_IS_ALT_FORM, isAltForm);
+
+        if (isAltForm && m_ptrs.flags1) {
+            // Boost path arbitration. MelonPrime holds a static center touch every
+            // frame for aim, so the game's boost gate cannot pick the right path on
+            // its own. The gate (around 020235C8) routes to the R hold-charge path
+            // only when CanTouchBoost (CPlayer +0x4C4 bit27) is clear; when it is
+            // set it takes the touch/aim path, which boosts when the aim-delta
+            // magnitude is large (a fast mouse flick = "aim boost"). With the touch
+            // held the game never re-arms CanTouchBoost on its own, so we drive it:
+            //  - button boost requested (right-click R, Shift auto-cycle, or a
+            //    charge already building) → clear it so the R path runs. The charge
+            //    counter (boostGauge = player+0x148) keeps it cleared through the
+            //    release frame so the boost actually fires.
+            //  - otherwise → set it so a fast aim flick still triggers the aim boost.
+            const bool buttonBoost = IsDown(IB_ZOOM)
+                || IsDown(IB_MORPH_BOOST)
+                || (*m_ptrs.boostGauge != 0);
+            if (buttonBoost)
+                *m_ptrs.flags1 &= ~0x08000000u;
+            else
+                *m_ptrs.flags1 |= 0x08000000u;
+        }
+
+        // Shift hold-to-boost auto-cycle (separate from the manual right-click R
+        // boost handled by ApplyZoomBindingInput).
+        if (!IsDown(IB_MORPH_BOOST)) {
+            return false;
+        }
 
         if (isAltForm) {
             const uint8_t boostGauge = *m_ptrs.boostGauge;


### PR DESCRIPTION
… kept

After transforming, pressing/releasing R did nothing until the player manually did one mouse-swing touch-boost. Root cause: MelonPrime holds a static center touch every frame for aim, which leaves the game's CanTouchBoost flag (CPlayer +0x4C4 bit27) stuck set. The boost gate then stays on the touch/aim branch and, with zero touch delta, never reaches the R hold-charge (button) path. The game only re-evaluates the flag when the touch is released, so with the touch held it can never arbitrate between the two boost styles on its own.

Drive the flag from MelonPrime every alt-form frame: clear it while a button boost is requested (right-click R, the Shift auto-cycle, or a charge already building via boostGauge) so the R path runs and fires on release; set it otherwise so a fast aim flick still triggers the touch/aim boost. Both boost styles now work together.

Also make ApplyZoomBindingInput press the legacy R bit in alt form, so the R boost binding is driven regardless of the configured zoom input method.

Adds m_ptrs.flags1 (CPlayer +0x4C4) resolved at game join.