### PR TITLE
Align BSD artifact names with .zip suffix for bundle job.

### DIFF
--- a/.github/workflows/build-bsd.yml
+++ b/.github/workflows/build-bsd.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Upload binary
       uses: actions/upload-artifact@v7
       with:
-        name: melonPrimeDS-bsd-${{ matrix.os }}-${{ matrix.arch }}
+        name: melonPrimeDS-bsd-${{ matrix.os }}-${{ matrix.arch }}.zip
         path: melonPrimeDS-bsd-${{ matrix.os }}-${{ matrix.arch }}.zip
         archive: false
 
@@ -141,7 +141,7 @@ jobs:
       uses: actions/download-artifact@v8
       continue-on-error: true
       with:
-        name: melonPrimeDS-bsd-freebsd-x86_64
+        name: melonPrimeDS-bsd-freebsd-x86_64.zip
         path: bsd-freebsd-x86_64
         skip-decompress: true
 
@@ -149,7 +149,7 @@ jobs:
       uses: actions/download-artifact@v8
       continue-on-error: true
       with:
-        name: melonPrimeDS-bsd-netbsd-x86_64
+        name: melonPrimeDS-bsd-netbsd-x86_64.zip
         path: bsd-netbsd-x86_64
         skip-decompress: true
 
@@ -157,7 +157,7 @@ jobs:
       uses: actions/download-artifact@v8
       continue-on-error: true
       with:
-        name: melonPrimeDS-bsd-openbsd-x86_64
+        name: melonPrimeDS-bsd-openbsd-x86_64.zip
         path: bsd-openbsd-x86_64
         skip-decompress: true
 


### PR DESCRIPTION
Match upload-artifact and download-artifact names to the .zip artifact IDs GitHub stores so All BSD artifacts can download and bundle the per-OS zips.