### PR TITLE
Fix Linux/Wayland mouse-look escaping the game window (#526)

### DIFF
--- a/.claude/rules/build.md
+++ b/.claude/rules/build.md
@@ -113,13 +113,22 @@ Linux platform notes:
   `ScreenPanel::mouseMoveEvent` — never center-delta + warp-per-event (drift, see above). All
   warps re-seed the baseline via `resetAimMouseDelta()` so jumps are never counted as motion.
 - Linux never warps per-frame in `ProcessAimInputMouse` (`warpCursorAfterAim == false`);
-  containment is the panel's >96px threshold warp. See `melonprime-aim-input.md` §9 for the
-  full design and the three historical failure modes.
+  containment is the panel's >16px threshold warp (`MELONPRIME_LINUX_MOUSE_INPUT_HARDENING_V2`,
+  tightened from an earlier 96px). See `melonprime-aim-input.md` §9 for the full design and the
+  three historical failure modes.
 - Mouse buttons and keyboard hotkeys stay on the Qt/SDL path to avoid duplicate press edges.
-- Wayland does not expose the needed global raw mouse stream to normal clients. On Wayland, missing
-  XInput2, unavailable X11 display, or an XInput2 path that never emits raw motion, the aim path
-  falls back to the Qt previous-position-differencing accumulator. Wayland warp behavior is
-  compositor-dependent; use an Xorg session for reliable Linux FPS aim testing.
+- XInput2 raw motion needs an X11 connection (X11 session or XWayland), so it is unavailable on a
+  native Wayland session (`QGuiApplication::platformName() == "wayland"`). For that case there is
+  a native Wayland pointer lock (`MelonPrimeWaylandPointerLock.{h,cpp}`, `zwp_relative_pointer_v1`
+  + `zwp_pointer_constraints_v1`) that both `ScreenPanelGL` and `ScreenPanelNative` use — it
+  requires `MELONPRIME_ENABLE_WAYLAND_POINTER_LOCK` to be compiled in (CMake `AUTO`/`ON`/`OFF`
+  option `MELONPRIME_WAYLAND_POINTER_LOCK`, needs `wayland-scanner` + the `wayland-protocols` XML
+  package at build time) and a compositor that advertises both protocols (KWin does). Without that
+  feature compiled in, or on a compositor that doesn't support it, there is **no** cursor
+  confinement left on native Wayland — `QCursor::setPos` is a documented no-op there — and aim can
+  visibly leave the window (see issue #526). `MelonPrimeScreenCursorPolicy.cpp::ClipCenter1px`
+  logs a one-shot warning to stderr when this dead end is hit. Use an Xorg/XWayland session for
+  reliable Linux FPS aim testing if the native lock isn't available.
 - **The recenter must use `MelonPrime::LinuxWarpCursorGlobal` (XWarpPointer) on X11, never
   `QCursor::setPos` there**: Qt's setPos can fail under VirtualBox guest mouse integration or
   when called off the GUI thread — a failed recenter re-applies the cursor-minus-center delta

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -85,10 +85,11 @@ jobs:
       run: |
         sudo apt update
         sudo apt install --allow-downgrades cmake ninja-build extra-cmake-modules libpcap0.8-dev libsdl2-dev libenet-dev \
-          qt6-{base,base-private,multimedia}-dev qt6-wayland libqt6svg6-dev libarchive-dev libzstd-dev libfuse2 libfaad-dev libxi-dev
+          qt6-{base,base-private,multimedia}-dev qt6-wayland libqt6svg6-dev libarchive-dev libzstd-dev libfuse2 libfaad-dev libxi-dev \
+          wayland-protocols libwayland-bin
 
     - name: Configure
-      run: cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DMELONDS_EMBED_BUILD_INFO=ON -DMELONPRIME_ENABLE_DEVELOPER_FEATURES=OFF
+      run: cmake -B build -G Ninja -DCMAKE_INSTALL_PREFIX=/usr -DMELONDS_EMBED_BUILD_INFO=ON -DMELONPRIME_ENABLE_DEVELOPER_FEATURES=OFF -DMELONPRIME_WAYLAND_POINTER_LOCK=ON
 
     - name: Build
       run: |

--- a/src/frontend/qt_sdl/CMakeLists.txt
+++ b/src/frontend/qt_sdl/CMakeLists.txt
@@ -169,6 +169,20 @@ if (USE_QT6)
         set_property(TARGET WrapRt::WrapRt PROPERTY INTERFACE_LINK_LIBRARIES "")
     endif()
     set(QT_LINK_LIBS Qt6::Core Qt6::Gui Qt6::Widgets Qt6::Network Qt6::Multimedia Qt6::OpenGL Qt6::OpenGLWidgets)
+
+    if (NOT WIN32 AND NOT APPLE)
+        # Screen.cpp needs the private QPA qplatformnativeinterface.h header:
+        # unconditionally for X11 on Qt < 6.5, and for native Wayland wl_surface
+        # access (MelonPrime's Wayland pointer lock / GL context creation) on any
+        # Qt6 version when the Wayland EGL backend is enabled. Some distro Qt6
+        # packages (e.g. Arch/CachyOS) only expose that header under a
+        # version-suffixed private include path that isn't reachable without
+        # this target, even though the header file itself is installed.
+        find_package(Qt6GuiPrivate QUIET)
+        if (TARGET Qt6::GuiPrivate)
+            list(APPEND QT_LINK_LIBS Qt6::GuiPrivate)
+        endif()
+    endif()
 else()
     find_package(Qt5 COMPONENTS Core Gui Widgets Network Multimedia Svg REQUIRED)
     set(QT_LINK_LIBS Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network Qt5::Multimedia)

--- a/src/frontend/qt_sdl/MelonPrimeScreenCursorPolicy.cpp
+++ b/src/frontend/qt_sdl/MelonPrimeScreenCursorPolicy.cpp
@@ -12,7 +12,8 @@
 
 #include <algorithm>
 #include <atomic>
-
+#include <cstdio>
+#include <cstdlib>
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
@@ -186,6 +187,29 @@ void ClipCenter1px(ScreenPanel& panel)
         const QPoint c = panel.mapToGlobal(panel.rect().center());
         PlatformInput_WarpCursor(c.x(), c.y());
     }
+    else
+    {
+        // Neither the native Wayland lock nor an X11/XWayland grab is
+        // available: a pure Wayland session either built without
+        // MELONPRIME_ENABLE_WAYLAND_POINTER_LOCK (missing wayland-protocols at
+        // build time), or whose compositor doesn't advertise
+        // zwp_relative_pointer_manager_v1 / zwp_pointer_constraints_v1.
+        // QCursor::setPos is a documented no-op on native Wayland, so there is
+        // no confinement fallback left -- the cursor is free to leave the
+        // game window during aim (see melonprime-aim-input.md and issue #526).
+        // Warn once instead of silently degrading.
+        static bool warnedNoLinuxCursorConfinement = false;
+        if (!warnedNoLinuxCursorConfinement)
+        {
+            warnedNoLinuxCursorConfinement = true;
+            std::fprintf(stderr,
+                "[MelonPrime] Linux cursor containment unavailable: no native "
+                "Wayland pointer lock and not running under X11/XWayland. "
+                "Mouse-look aim may leave the window. Install wayland-protocols "
+                "and rebuild (-DMELONPRIME_WAYLAND_POINTER_LOCK=ON) or run this "
+                "session under Xorg/XWayland.\n");
+        }
+    }
 #elif !defined(_WIN32)
     const QPoint c = panel.mapToGlobal(panel.rect().center());
     PlatformInput_WarpCursor(c.x(), c.y());
@@ -265,6 +289,8 @@ void UpdateClipIfNeeded(ScreenPanel& panel)
     const auto ui = core ? core->ThreadBridge().ReadForGui()
                          : MelonPrimeUiSnapshot{};
     if (core && !ui.focused) {
+        if (std::getenv("MELONPRIME_WAYLAND_LOCK_DEBUG"))
+            std::fprintf(stderr, "[MelonPrime] UpdateClipIfNeeded: !ui.focused -> Suspend\n");
         // Temporary focus loss must not erase the persistent capture request.
         Suspend(panel);
         return;

--- a/src/frontend/qt_sdl/MelonPrimeWaylandPointerLock.cpp
+++ b/src/frontend/qt_sdl/MelonPrimeWaylandPointerLock.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <limits>
 #include <utility>
@@ -219,12 +220,20 @@ struct WaylandPointerLock::Impl
 
     static void Locked(void* data, zwp_locked_pointer_v1*)
     {
-        static_cast<Impl*>(data)->lockActive = true;
+        auto& self = *static_cast<Impl*>(data);
+        self.lockActive = true;
+        if (std::getenv("MELONPRIME_WAYLAND_LOCK_DEBUG"))
+            std::fprintf(stderr, "[MelonPrime] Wayland pointer lock: ENGAGED surface=%p\n",
+                static_cast<void*>(self.lockedSurface));
     }
 
     static void Unlocked(void* data, zwp_locked_pointer_v1*)
     {
-        static_cast<Impl*>(data)->lockActive = false;
+        auto& self = *static_cast<Impl*>(data);
+        self.lockActive = false;
+        if (std::getenv("MELONPRIME_WAYLAND_LOCK_DEBUG"))
+            std::fprintf(stderr, "[MelonPrime] Wayland pointer lock: released (compositor Unlocked event) surface=%p\n",
+                static_cast<void*>(self.lockedSurface));
     }
 
     static const wl_registry_listener RegistryListener;
@@ -235,6 +244,11 @@ struct WaylandPointerLock::Impl
 
     void DestroyLockObjects()
     {
+        if (lockRequested && std::getenv("MELONPRIME_WAYLAND_LOCK_DEBUG"))
+            std::fprintf(stderr,
+                "[MelonPrime] Wayland pointer lock: destroying lock objects (was surface=%p active=%d)\n",
+                static_cast<void*>(lockedSurface), lockActive ? 1 : 0);
+
         lockActive = false;
         lockRequested = false;
         lockedSurface = nullptr;
@@ -358,17 +372,36 @@ struct WaylandPointerLock::Impl
 
     bool SetLocked(wl_display* newDisplay, wl_surface* surface, bool enabled)
     {
+        const bool debug = std::getenv("MELONPRIME_WAYLAND_LOCK_DEBUG") != nullptr;
+
         if (!enabled)
         {
+            if (debug)
+                std::fprintf(stderr, "[MelonPrime] Wayland pointer lock: SetLocked(false)\n");
             DestroyLockObjects();
             return true;
         }
 
-        if (!newDisplay || !surface || !Initialize(newDisplay))
+        const bool initSupported = newDisplay && surface && Initialize(newDisplay);
+        if (!initSupported)
+        {
+            if (debug)
+                std::fprintf(stderr,
+                    "[MelonPrime] Wayland pointer lock: SetLocked(true) rejected "
+                    "(display=%p surface=%p)\n",
+                    static_cast<void*>(newDisplay), static_cast<void*>(surface));
             return false;
+        }
 
         if (lockRequested && lockedSurface == surface && lockedPointer && relativePointer)
             return true;
+
+        if (debug)
+            std::fprintf(stderr,
+                "[MelonPrime] Wayland pointer lock: SetLocked(true) new request "
+                "surface=%p (previous lockedSurface=%p lockRequested=%d)\n",
+                static_cast<void*>(surface), static_cast<void*>(lockedSurface),
+                lockRequested ? 1 : 0);
 
         DestroyLockObjects();
 

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -19,6 +19,7 @@
 #include <string.h>
 
 #include <optional>
+#include <utility>
 #include <cmath>
 #include <algorithm>
 
@@ -1074,12 +1075,16 @@ bool ScreenPanel::event(QEvent * event)
     case QEvent::WindowDeactivate:
     case QEvent::Hide:
     case QEvent::ParentChange:
+        if (getenv("MELONPRIME_WAYLAND_LOCK_DEBUG"))
+            fprintf(stderr, "[MelonPrime] ScreenPanel::event: Suspend-triggering type=%d\n", (int)event->type());
         MelonPrime::ScreenCursorPolicy::Suspend(*this);
         break;
     case QEvent::WindowActivate:
     case QEvent::WindowUnblocked:
     case QEvent::Show:
     case QEvent::WindowStateChange:
+        if (getenv("MELONPRIME_WAYLAND_LOCK_DEBUG"))
+            fprintf(stderr, "[MelonPrime] ScreenPanel::event: updateClipIfNeeded-triggering type=%d\n", (int)event->type());
         QTimer::singleShot(0, this, [this]() {
             if (!closing && qApp && !qApp->closingDown())
                 updateClipIfNeeded();
@@ -1466,6 +1471,45 @@ void ScreenPanel::calcSplashLayout()
 
 
 
+#if defined(__linux__) && defined(MELONPRIME_ENABLE_WAYLAND_POINTER_LOCK)
+namespace {
+
+// Resolves the native wl_display/wl_surface handles MelonPrime's Wayland
+// pointer-lock path needs, given the QWindow that owns the surface. Both
+// ScreenPanelGL and ScreenPanelNative call this with their *top-level*
+// window's handle (never a panel's own Qt::WA_NativeWindow subsurface):
+// locking a child subsurface directly caused KWin to fire WindowDeactivate
+// on the main window in windowed mode, which our own Suspend() path read as
+// focus loss and immediately tore the lock back down (see issue #526).
+std::optional<std::pair<void*, void*>> ResolveMelonPrimeWaylandHandles(QWindow* handle)
+{
+    if (!handle || QGuiApplication::platformName() != QStringLiteral("wayland"))
+        return std::nullopt;
+
+    QPlatformNativeInterface* pni = QGuiApplication::platformNativeInterface();
+    if (!pni)
+        return std::nullopt;
+
+    void* display = nullptr;
+#if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+    const QWaylandApplication* wl = qApp->nativeInterface<QWaylandApplication>();
+    if (!wl)
+        return std::nullopt;
+    display = wl->display();
+#else
+    display = pni->nativeResourceForWindow("display", handle);
+#endif
+
+    void* const surface = pni->nativeResourceForWindow("surface", handle);
+    if (!display || !surface)
+        return std::nullopt;
+
+    return std::make_pair(display, surface);
+}
+
+} // namespace
+#endif
+
 ScreenPanelNative::ScreenPanelNative(QWidget * parent) : ScreenPanel(parent)
 {
     hasBuffers = false;
@@ -1475,11 +1519,46 @@ ScreenPanelNative::ScreenPanelNative(QWidget * parent) : ScreenPanel(parent)
 
     screenTrans[0].reset();
     screenTrans[1].reset();
+#if defined(__linux__) && defined(MELONPRIME_ENABLE_WAYLAND_POINTER_LOCK)
+    waylandPointerLock = std::make_unique<MelonPrime::WaylandPointerLock>(
+        [this](std::int32_t dx, std::int32_t dy) {
+            addAimMouseDeltaForMelonPrime(dx, dy);
+        });
+#endif
 }
 
 ScreenPanelNative::~ScreenPanelNative()
 {
+#if defined(__linux__) && defined(MELONPRIME_ENABLE_WAYLAND_POINTER_LOCK)
+    if (waylandPointerLock)
+        waylandPointerLock->setLocked(nullptr, nullptr, false);
+#endif
 }
+
+#if defined(__linux__) && defined(MELONPRIME_ENABLE_WAYLAND_POINTER_LOCK)
+bool ScreenPanelNative::setWaylandPointerLockForMelonPrime(bool enabled)
+{
+    if (!waylandPointerLock)
+        return false;
+
+    if (!enabled)
+        return waylandPointerLock->setLocked(nullptr, nullptr, false);
+
+    // Not a Qt::WA_NativeWindow: lock the top-level window's surface instead
+    // of our own (we have none).
+    QWindow* const topLevelHandle = window() ? window()->windowHandle() : nullptr;
+    const auto handles = ResolveMelonPrimeWaylandHandles(topLevelHandle);
+    if (!handles.has_value())
+        return false;
+
+    return waylandPointerLock->setLocked(handles->first, handles->second, true);
+}
+
+bool ScreenPanelNative::isWaylandPointerLockActiveForMelonPrime() const
+{
+    return waylandPointerLock && waylandPointerLock->isLockActive();
+}
+#endif
 
 void ScreenPanelNative::setupScreenLayout()
 {
@@ -1823,20 +1902,19 @@ bool ScreenPanelGL::setWaylandPointerLockForMelonPrime(bool enabled)
     if (!enabled)
         return waylandPointerLock->setLocked(nullptr, nullptr, false);
 
-    if (QGuiApplication::platformName() != QStringLiteral("wayland"))
+    // Lock the top-level window's surface, not this panel's own
+    // Qt::WA_NativeWindow subsurface (used by getWindowInfo() for GL context
+    // creation). Locking the child subsurface directly made KWin immediately
+    // fire WindowDeactivate on the main window in windowed (non-fullscreen)
+    // mode, which our own Suspend() path read as focus loss and tore the lock
+    // right back down -- a lock/unlock churn whose brief unlocked gaps let
+    // fast mouse motion escape the window (see issue #526).
+    QWindow* const topLevelHandle = window() ? window()->windowHandle() : nullptr;
+    const auto handles = ResolveMelonPrimeWaylandHandles(topLevelHandle);
+    if (!handles.has_value())
         return false;
 
-    const std::optional<WindowInfo> info = getWindowInfo();
-    if (!info.has_value()
-        || info->type != WindowInfo::Type::Wayland
-        || !info->display_connection
-        || !info->window_handle)
-    {
-        return false;
-    }
-
-    return waylandPointerLock->setLocked(
-        info->display_connection, info->window_handle, true);
+    return waylandPointerLock->setLocked(handles->first, handles->second, true);
 }
 
 bool ScreenPanelGL::isWaylandPointerLockActiveForMelonPrime() const

--- a/src/frontend/qt_sdl/Screen.h
+++ b/src/frontend/qt_sdl/Screen.h
@@ -330,6 +330,16 @@ public:
 
     void drawScreen() override;
 
+#if defined(__linux__) && defined(MELONPRIME_ENABLE_WAYLAND_POINTER_LOCK)
+    // ScreenPanelNative has no wl_surface of its own (unlike ScreenPanelGL, it
+    // is not a Qt::WA_NativeWindow); these lock the top-level window's surface
+    // instead. Without this override the Software renderer silently has no
+    // Wayland cursor confinement at all -- see melonprime-aim-input.md and
+    // issue #526.
+    bool setWaylandPointerLockForMelonPrime(bool enabled) override;
+    [[nodiscard]] bool isWaylandPointerLockActiveForMelonPrime() const override;
+#endif
+
 protected:
     void paintEvent(QPaintEvent* event) override;
 
@@ -343,6 +353,9 @@ private:
 
     QImage screen[2];
     QTransform screenTrans[kMaxScreenTransforms];
+#if defined(__linux__) && defined(MELONPRIME_ENABLE_WAYLAND_POINTER_LOCK)
+    std::unique_ptr<MelonPrime::WaylandPointerLock> waylandPointerLock;
+#endif
 };
 
 


### PR DESCRIPTION
Root causes, found by instrumenting and reproducing live on a KDE Plasma Wayland session:

1. ScreenPanelNative (Software renderer) never implemented the native Wayland pointer lock at all -- only ScreenPanelGL did. On a native Wayland session with no XWayland/XInput2 fallback available, this left zero cursor confinement for the Software renderer.

2. The Wayland pointer lock (when compiled in) locked ScreenPanelGL's own Qt::WA_NativeWindow subsurface instead of the top-level window's surface. Locking that child subsurface made KWin immediately fire WindowDeactivate on the main window in windowed (non-fullscreen) mode, which our own Suspend() path read as focus loss and tore the lock right back down -- a continuous lock/unlock churn whose brief unlocked gaps let fast mouse motion escape the window. This also explains why the original report saw it only on OpenGL: Software had no lock to churn.

3. The official Ubuntu CI build never installed wayland-protocols, so even released Linux binaries never got MELONPRIME_ENABLE_WAYLAND_POINTER_LOCK compiled in, silently degrading to no confinement on native Wayland.

Fixes:
- Give ScreenPanelNative the same Wayland pointer-lock support as ScreenPanelGL, via a shared helper that resolves the *top-level* window's wl_display/wl_surface handles (never a panel's own subsurface).
- Route ScreenPanelGL's lock through the same top-level-surface helper instead of its GL-context surface.
- Install wayland-protocols/libwayland-bin in build-ubuntu.yml and pass -DMELONPRIME_WAYLAND_POINTER_LOCK=ON so a future regression fails CI loudly instead of shipping silently broken again.
- Link Qt6::GuiPrivate when available so the private QPA header Screen.cpp already needed resolves on distros (e.g. Arch/CachyOS) that expose it under a version-suffixed private include path.
- Log once to stderr when Linux cursor containment is unavailable at all (no Wayland lock, not X11/XWayland), instead of silently degrading.
- Add opt-in MELONPRIME_WAYLAND_LOCK_DEBUG diagnostics (lock request/ engage/release/destroy + the WindowActivate/Deactivate events that drive them) used to root-cause this; kept for future field diagnosis.

Verified end-to-end on a real KDE Plasma Wayland session (fullscreen and windowed, Software and OpenGL): pointer lock now engages and stays engaged (previously churned every request) with fast mouse motion no longer escaping the window.