### PR TITLE
Recenter Wayland cursor on pointer-lock release (#526 follow-up)

### DIFF
--- a/src/frontend/qt_sdl/MelonPrimeWaylandPointerLock.cpp
+++ b/src/frontend/qt_sdl/MelonPrimeWaylandPointerLock.cpp
@@ -63,6 +63,12 @@ struct WaylandPointerLock::Impl
     double residualX = 0.0;
     double residualY = 0.0;
 
+    // Cursor position hint (surface-local, see set_cursor_position_hint in
+    // the pointer-constraints protocol), refreshed on every enabled=true
+    // SetLocked() call and reused as the release hint by DestroyLockObjects().
+    double hintX = 0.0;
+    double hintY = 0.0;
+
     static void RegistryGlobal(
         void* data,
         wl_registry* registryObject,
@@ -246,8 +252,23 @@ struct WaylandPointerLock::Impl
     {
         if (lockRequested && std::getenv("MELONPRIME_WAYLAND_LOCK_DEBUG"))
             std::fprintf(stderr,
-                "[MelonPrime] Wayland pointer lock: destroying lock objects (was surface=%p active=%d)\n",
-                static_cast<void*>(lockedSurface), lockActive ? 1 : 0);
+                "[MelonPrime] Wayland pointer lock: destroying lock objects (was surface=%p active=%d hint=%.1f,%.1f)\n",
+                static_cast<void*>(lockedSurface), lockActive ? 1 : 0, hintX, hintY);
+
+        // Tell the compositor where to warp the (invisible) cursor once this
+        // lock releases -- per the protocol, this is the mechanism meant to
+        // "avoid pointer jumps" on unlock. Without it the cursor stays
+        // wherever it was frozen (often near a window edge from before the
+        // lock engaged), so a later re-lock's brief unlocked gap can let it
+        // escape the window on the very next fast motion. Must happen before
+        // lockedPointer/lockedSurface are torn down, and needs a commit on
+        // the locked surface for the double-buffered hint to take effect.
+        if (lockedPointer && lockedSurface)
+        {
+            zwp_locked_pointer_v1_set_cursor_position_hint(
+                lockedPointer, wl_fixed_from_double(hintX), wl_fixed_from_double(hintY));
+            wl_surface_commit(lockedSurface);
+        }
 
         lockActive = false;
         lockRequested = false;
@@ -370,9 +391,16 @@ struct WaylandPointerLock::Impl
         return supported;
     }
 
-    bool SetLocked(wl_display* newDisplay, wl_surface* surface, bool enabled)
+    bool SetLocked(wl_display* newDisplay, wl_surface* surface, bool enabled,
+        int hintSurfaceX, int hintSurfaceY)
     {
         const bool debug = std::getenv("MELONPRIME_WAYLAND_LOCK_DEBUG") != nullptr;
+
+        if (enabled)
+        {
+            hintX = static_cast<double>(hintSurfaceX);
+            hintY = static_cast<double>(hintSurfaceY);
+        }
 
         if (!enabled)
         {
@@ -499,12 +527,16 @@ WaylandPointerLock::~WaylandPointerLock()
 bool WaylandPointerLock::setLocked(
     void* displayHandle,
     void* surfaceHandle,
-    bool enabled)
+    bool enabled,
+    int hintSurfaceX,
+    int hintSurfaceY)
 {
     return m_impl->SetLocked(
         static_cast<wl_display*>(displayHandle),
         static_cast<wl_surface*>(surfaceHandle),
-        enabled);
+        enabled,
+        hintSurfaceX,
+        hintSurfaceY);
 }
 
 bool WaylandPointerLock::isLockRequested() const noexcept

--- a/src/frontend/qt_sdl/MelonPrimeWaylandPointerLock.h
+++ b/src/frontend/qt_sdl/MelonPrimeWaylandPointerLock.h
@@ -21,8 +21,15 @@ public:
     WaylandPointerLock& operator=(const WaylandPointerLock&) = delete;
 
     // displayHandle must be wl_display*, surfaceHandle must be wl_surface*.
-    // Neither object is owned by this class.
-    bool setLocked(void* displayHandle, void* surfaceHandle, bool enabled);
+    // Neither object is owned by this class. hintSurfaceX/Y are the point
+    // (in the locked surface's local coordinate space, e.g. the DS panel's
+    // center mapped into the top-level window) the compositor should warp
+    // the (invisible) cursor to whenever the lock is released -- this keeps
+    // the cursor away from the window edge if a later re-lock exposes it
+    // during a brief gap. Ignored when enabled is false; the most recent
+    // hint from a prior enabled=true call is reused for that release.
+    bool setLocked(void* displayHandle, void* surfaceHandle, bool enabled,
+        int hintSurfaceX = 0, int hintSurfaceY = 0);
 
     [[nodiscard]] bool isLockRequested() const noexcept;
     [[nodiscard]] bool isLockActive() const noexcept;

--- a/src/frontend/qt_sdl/Screen.cpp
+++ b/src/frontend/qt_sdl/Screen.cpp
@@ -1551,7 +1551,12 @@ bool ScreenPanelNative::setWaylandPointerLockForMelonPrime(bool enabled)
     if (!handles.has_value())
         return false;
 
-    return waylandPointerLock->setLocked(handles->first, handles->second, true);
+    // Hint the panel's own center, expressed in the locked (top-level)
+    // surface's local coordinates, so the compositor recenters the cursor
+    // away from any edge whenever this lock later releases.
+    const QPoint hint = window() ? mapTo(window(), rect().center()) : rect().center();
+    return waylandPointerLock->setLocked(
+        handles->first, handles->second, true, hint.x(), hint.y());
 }
 
 bool ScreenPanelNative::isWaylandPointerLockActiveForMelonPrime() const
@@ -1914,7 +1919,12 @@ bool ScreenPanelGL::setWaylandPointerLockForMelonPrime(bool enabled)
     if (!handles.has_value())
         return false;
 
-    return waylandPointerLock->setLocked(handles->first, handles->second, true);
+    // Hint the panel's own center, expressed in the locked (top-level)
+    // surface's local coordinates, so the compositor recenters the cursor
+    // away from any edge whenever this lock later releases.
+    const QPoint hint = window() ? mapTo(window(), rect().center()) : rect().center();
+    return waylandPointerLock->setLocked(
+        handles->first, handles->second, true, hint.x(), hint.y());
 }
 
 bool ScreenPanelGL::isWaylandPointerLockActiveForMelonPrime() const


### PR DESCRIPTION
Field report after the previous fix: mouse-look is now playable, but occasionally the cursor still escapes the window and needs a click on the menu bar then back on the DS screen to re-lock. The reporter's video showed the cursor sitting at the window edge right before it escaped.

While truly locked, the pointer-constraints protocol freezes the OS cursor wherever it was when the lock engaged -- it never moves visually. But any brief unlock (the occasional legitimate Suspend from a real focus event, or a transient re-lock) exposes that frozen position. If it happened to be near an edge, fast mouse motion during that exposed window travels out of the game window almost immediately; if it's centered, the same motion has much further to travel before it can escape.

The pointer-constraints protocol has a purpose-built mechanism for this: zwp_locked_pointer_v1::set_cursor_position_hint, documented to let a compositor "warp the pointer upon unlock in order to avoid pointer jumps". WaylandPointerLock now tracks the panel's center (mapped into the locked top-level surface's local coordinates) on every lock request, and emits that hint + a surface commit right before tearing down the lock object in DestroyLockObjects() -- covering both real unlocks and the internal re-lock-with-fresh-object path.

Verified live on the same KDE Plasma Wayland session: cursor now recenters whenever the lock releases.