### PR TITLE
Gate the force-software renderer on the match black-to-black window

### DIFF
--- a/src/frontend/qt_sdl/EmuThread.cpp
+++ b/src/frontend/qt_sdl/EmuThread.cpp
@@ -340,14 +340,15 @@ void EmuThread::run()
             melonPrime->RunFrameHook();
             emuInstance->nds->SetKeyMask(melonPrime->GetInputMaskFast());
 #if defined(MELONPRIME_DS)
-            // Renderer switching follows the ROM's broad in-game state rather
-            // than the narrower patch lifecycle. This keeps the selected GPU
-            // renderer active through match-end presentation until the game
-            // itself clears its in-game flag.
-            const bool rendererIsInGame = melonPrime->IsInGame();
-            if (UNLIKELY(rendererIsInGame != rendererWasInGame))
+            // Renderer switching follows the match window between the
+            // pre-match and post-match full blacks, not the patch lifecycle or
+            // the ROM's in-game flag. Uses the same predicate as the switch
+            // below so the edge and the decision cannot diverge.
+            const bool rendererIsHardwarePeriod =
+                !melonPrime->ShouldForceSoftwareRenderer();
+            if (UNLIKELY(rendererIsHardwarePeriod != rendererWasHardwarePeriod))
             {
-                rendererWasInGame = rendererIsInGame;
+                rendererWasHardwarePeriod = rendererIsHardwarePeriod;
                 const int requestedRenderer = globalCfg.GetInt("3D.Renderer");
                 bool forceSoftwareOutsideMatch =
                     globalCfg.GetBool("3D.ForceSoftwareOutsideMatch");

--- a/src/frontend/qt_sdl/EmuThread.h
+++ b/src/frontend/qt_sdl/EmuThread.h
@@ -245,7 +245,9 @@ private:
     int videoRenderer;
     bool videoSettingsDirty;
 #ifdef MELONPRIME_DS
-    bool rendererWasInGame = false;
+    // Previous frame's hardware-renderer period; edge-triggers the
+    // force-software renderer switch.
+    bool rendererWasHardwarePeriod = false;
 #endif
 };
 

--- a/src/frontend/qt_sdl/MelonPrime.cpp
+++ b/src/frontend/qt_sdl/MelonPrime.cpp
@@ -237,11 +237,6 @@ namespace MelonPrime {
 
     void MelonPrimeCore::OnReset() { OnEmuStart(); }
 
-    bool MelonPrimeCore::ShouldForceSoftwareRenderer() const
-    {
-        return !IsInGame();
-    }
-
     bool MelonPrimeCore::ShouldSuppressVulkanHelmetLayers() const
     {
 #if defined(MELONPRIME_CUSTOM_HUD) && defined(MELONPRIME_ENABLE_VULKAN)
@@ -334,6 +329,15 @@ namespace MelonPrime {
             const bool isInGame = (*m_ptrs.inGame) == 0x0001;
             const bool wasInGame = m_flags.test(StateFlags::BIT_IN_GAME);
             m_flags.assign(StateFlags::BIT_IN_GAME, isInGame);
+
+            // Match window: pre-match full black lifts -> ... -> post-match
+            // fade reaches full black. One state-machine step per emulated
+            // frame. The pointer bundle is resolved at ROM detect and the
+            // update reads lazily; the steady state costs one u8 read.
+            m_flags.assign(
+                StateFlags::BIT_MATCH_BETWEEN_BLACKOUTS,
+                BattleFlow::UpdateMatchBetweenBlackouts(
+                    m_matchBlackWindow, m_matchTransitionPtrs));
 
             // Join / rematch: legacy inGame rising edge, or unpause clearing INIT.
             // Rising edge always re-inits (lobby / rematch) even if RESTORED was left set.

--- a/src/frontend/qt_sdl/MelonPrime.h
+++ b/src/frontend/qt_sdl/MelonPrime.h
@@ -22,6 +22,7 @@ class ScreenPanel;  // P-3: forward decl for cached panel pointer
 #include "MelonPrimeThreadBridge.h"
 #include "MelonPrimeGameSettings.h"
 #include "MelonPrimeGameRomAddrTable.h"
+#include "MelonPrimeBattleFlowState.h"
 #include "MelonPrimeZoomState.h"
 #ifdef MELONPRIME_DS
 #include "MelonPrimePatchShadowFreezeRuntimeHook.h"
@@ -152,6 +153,8 @@ namespace MelonPrime {
         uint8_t* weaponChange;
 
         // [Tier 3: Conditional / Rare]
+        // The match black-window state machine reads its own inputs through
+        // MatchTransitionPtrs, not through this struct.
         uint8_t* currentMode;       // isEndOfGame poll (only while in-game init, pre-restore)
         uint8_t* battleFlowState;
         uint8_t* selectedWeapon;
@@ -227,7 +230,19 @@ namespace MelonPrime {
         void SetFrameAdvanceFunc(std::function<void()> func);
 
         [[nodiscard]] FORCE_INLINE bool IsInGame() const { return m_flags.test(StateFlags::BIT_IN_GAME); }
-        [[nodiscard]] bool ShouldForceSoftwareRenderer() const;
+        // True from the frame the pre-match full black lifts until the frame
+        // the post-match fade reaches full black. See
+        // BattleFlow::UpdateMatchBetweenBlackouts.
+        [[nodiscard]] FORCE_INLINE bool IsMatchBetweenBlackoutsActive() const {
+            return m_flags.test(StateFlags::BIT_MATCH_BETWEEN_BLACKOUTS);
+        }
+        // The match window is the definition of "in a match" for the
+        // force-software-outside-match feature; the ROM's in-game flag is not
+        // consulted. Called every frame by EmuThread's renderer-switch edge
+        // check, so it stays inline: one flags load, no call.
+        [[nodiscard]] FORCE_INLINE bool ShouldForceSoftwareRenderer() const {
+            return !IsMatchBetweenBlackoutsActive();
+        }
         [[nodiscard]] bool ShouldSuppressVulkanHelmetLayers() const;
         [[nodiscard]] uint16_t GetInputMaskFast() const { return m_inputMaskFast; }
 #if MELONPRIME_PLATFORM_RAW_FILTER_ENABLED
@@ -600,12 +615,21 @@ namespace MelonPrime {
             static constexpr uint32_t BIT_STYLUS_MODE = 1u << 11;
             static constexpr uint32_t BIT_LAST_FOCUSED = 1u << 13;
             static constexpr uint32_t BIT_BLOCK_STYLUS = 1u << 14;
+            // Between the pre-match and post-match full blacks; see
+            // IsMatchBetweenBlackoutsActive().
+            static constexpr uint32_t BIT_MATCH_BETWEEN_BLACKOUTS = 1u << 16;
 
             FORCE_INLINE void set(uint32_t bit) { packed |= bit; }
             FORCE_INLINE void clear(uint32_t bit) { packed &= ~bit; }
             FORCE_INLINE void assign(uint32_t bit, bool val) { packed = (packed & ~bit) | (val ? bit : 0u); }
             [[nodiscard]] FORCE_INLINE bool test(uint32_t bit) const { return (packed & bit) != 0; }
         } m_flags{};
+
+        // Drives BIT_MATCH_BETWEEN_BLACKOUTS. Reset with the flags on every
+        // ROM / session / instance lifecycle transition; the pointers are
+        // resolved once per ROM detect.
+        BattleFlow::MatchBlackWindowState m_matchBlackWindow{};
+        BattleFlow::MatchTransitionPtrs m_matchTransitionPtrs{};
 
         // --- Warm: Frame advance + platform ---
         std::function<void()> m_frameAdvanceFunc;

--- a/src/frontend/qt_sdl/MelonPrimeBattleFlowState.h
+++ b/src/frontend/qt_sdl/MelonPrimeBattleFlowState.h
@@ -7,10 +7,18 @@
 
 namespace MelonPrime::BattleFlow {
 
+    constexpr uint8_t MODE_BATTLE_PRE     = 0x0Du;  // intermediate mode entered just before Battle
     constexpr uint8_t MODE_BATTLE_RUNTIME = 0x0Eu;
     constexpr uint8_t FLOW_ACTIVE_MATCH   = 0u;
     constexpr uint8_t FLOW_END_CAMERA     = 1u;
     constexpr uint8_t FLOW_RESULT         = 2u;
+
+    // MASTER_BRIGHT mode transition fade fields.
+    constexpr uint8_t TRANSITION_TYPE_DARKEN      = 1u;
+    constexpr uint8_t TRANSITION_PHASE_FADE_OUT   = 1u;  // darkening, not yet fully black
+    constexpr uint8_t TRANSITION_PHASE_FULL_BLACK = 2u;  // full black reached / callback boundary
+    constexpr uint8_t TRANSITION_PHASE_FADE_IN    = 3u;  // coming back out of full black
+    constexpr int32_t BRIGHTNESS_FULL_BLACK       = -16; // darken factor 16 == fully black
 
     // isEndOfGame: currentMode guard required (flowState alone is unsafe in menu).
     // After mode==0x0E is known, flow!=0 matches game active-match gates (0..3, only 0 is live).
@@ -19,6 +27,174 @@ namespace MelonPrime::BattleFlow {
         if (currentMode != MODE_BATTLE_RUNTIME)
             return false;
         return flowState != FLOW_ACTIVE_MATCH;
+    }
+
+    // =========================================================================
+    //  Match window between the pre-match and post-match full-black fades
+    //
+    //  Detects, as one continuous per-frame boolean:
+    //      pre-match full black ends  -> true
+    //      start presentation / live match / scoreboard / end camera
+    //      post-match fade reaches full black -> false
+    //      result-screen fade-in stays false
+    //
+    //  Full black alone cannot be told apart from other screen transitions, so
+    //  entry additionally requires a Battle context and exit requires a
+    //  post-match context. Exit arms on the post-match fade first so a mode
+    //  commit on the full-black frame cannot make the end edge be missed.
+    //
+    //  Hot path: the update takes RAM pointers, not a snapshot, and reads
+    //  lazily. transitionType is the cheapest discriminator -- with no darken
+    //  transition running the screen cannot be fully black and the post-match
+    //  fade cannot arm, so every other field is skipped. The mode/flow context
+    //  is only read on frames that are actually fully black, and the
+    //  post-match context is not re-read once armed.
+    // =========================================================================
+
+    // Resolved once per ROM detect; all fields are fixed globals.
+    struct MatchTransitionPtrs {
+        const int32_t* transitionBrightness;  // signed: full black is <= -16
+        const uint8_t* currentMode;
+        const uint8_t* pendingMode;
+        const uint8_t* flowState;
+        const uint8_t* transitionTargetMode;
+        const uint8_t* transitionPhase;
+        const uint8_t* transitionType;
+    };
+
+    struct MatchBlackWindowState {
+        enum Phase : uint8_t {
+            WAIT_START_BLACK = 0,   // waiting for the pre-match full black
+            WAIT_START_BLACK_EXIT,  // in the pre-match full black, waiting for it to lift
+            ACTIVE,                 // the target window
+        };
+        uint8_t phase = WAIT_START_BLACK;
+        bool postMatchFadeArmed = false;
+        // Set on every lifecycle reset: the first evaluated frame may land in
+        // the middle of a match (savestate load), where the pre-match full
+        // black can never be observed.
+        bool needsBootstrap = true;
+    };
+
+    // phase is already known to be a darken phase; only brightness is left.
+    [[nodiscard]] FORCE_INLINE bool IsBlackPhase(uint8_t transitionPhase) noexcept
+    {
+        return transitionPhase == TRANSITION_PHASE_FULL_BLACK
+            || transitionPhase == TRANSITION_PHASE_FADE_IN;
+    }
+
+    [[nodiscard]] FORCE_INLINE bool IsPostMatchContext(const MatchTransitionPtrs& p) noexcept
+    {
+        return *p.currentMode == MODE_BATTLE_RUNTIME && *p.flowState == FLOW_RESULT;
+    }
+
+    // Cold: only reachable on the first frame after a lifecycle reset.
+    COLD_FUNCTION inline void BootstrapMatchBlackWindow(
+        MatchBlackWindowState& st, const MatchTransitionPtrs& p) noexcept
+    {
+        st.needsBootstrap = false;
+
+        // Attaching mid-match: enter ACTIVE directly instead of waiting for a
+        // pre-match full black that already happened. Outside a match
+        // currentMode is not the Battle runtime, so a normal boot does not
+        // bootstrap and the strict pre-match observation still applies.
+        if (*p.currentMode != MODE_BATTLE_RUNTIME)
+            return;
+
+        const bool darkening = (*p.transitionType == TRANSITION_TYPE_DARKEN);
+        const uint8_t transitionPhase = darkening ? *p.transitionPhase : 0u;
+        const bool fullBlack = darkening
+            && IsBlackPhase(transitionPhase)
+            && *p.transitionBrightness <= BRIGHTNESS_FULL_BLACK;
+        if (fullBlack)
+            return;
+
+        st.phase = MatchBlackWindowState::ACTIVE;
+        st.postMatchFadeArmed = darkening
+            && transitionPhase == TRANSITION_PHASE_FADE_OUT
+            && IsPostMatchContext(p);
+    }
+
+    // One call per emulated frame. Returns the window state for that frame.
+    //
+    // Steady-state cost is one u8 read (transitionType). Everything else is
+    // read only on the branch that needs it -- see the header comment above.
+    [[nodiscard]] FORCE_INLINE bool UpdateMatchBetweenBlackouts(
+        MatchBlackWindowState& st, const MatchTransitionPtrs& p) noexcept
+    {
+        if (UNLIKELY(st.needsBootstrap))
+            BootstrapMatchBlackWindow(st, p);
+
+        // No darken transition running: cannot be fully black, and the
+        // post-match fade cannot arm. This is the common case both in a live
+        // match and in menus, and it exits after a single RAM read.
+        const bool darkening = (*p.transitionType == TRANSITION_TYPE_DARKEN);
+
+        switch (st.phase) {
+        case MatchBlackWindowState::ACTIVE: {
+            if (LIKELY(!darkening))
+                return true;
+
+            const uint8_t transitionPhase = *p.transitionPhase;
+
+            // Fade out is never fully black, so arming and the exit test are
+            // mutually exclusive frames.
+            if (transitionPhase == TRANSITION_PHASE_FADE_OUT) {
+                if (!st.postMatchFadeArmed && IsPostMatchContext(p))
+                    st.postMatchFadeArmed = true;
+                return true;
+            }
+
+            if (!IsBlackPhase(transitionPhase)
+                || *p.transitionBrightness > BRIGHTNESS_FULL_BLACK)
+                return true;
+
+            // Fully black: close the window only in a post-match context.
+            if (st.postMatchFadeArmed || IsPostMatchContext(p)) {
+                st.phase = MatchBlackWindowState::WAIT_START_BLACK;
+                st.postMatchFadeArmed = false;
+                return false;
+            }
+            return true;
+        }
+
+        case MatchBlackWindowState::WAIT_START_BLACK: {
+            if (LIKELY(!darkening))
+                return false;
+            if (!IsBlackPhase(*p.transitionPhase)
+                || *p.transitionBrightness > BRIGHTNESS_FULL_BLACK)
+                return false;
+
+            // Fully black. Only now is the mode/flow context worth reading.
+            const bool startMatchContext = !IsPostMatchContext(p)
+                && (*p.transitionTargetMode == MODE_BATTLE_PRE
+                    || *p.transitionTargetMode == MODE_BATTLE_RUNTIME
+                    || *p.currentMode == MODE_BATTLE_PRE
+                    || *p.pendingMode == MODE_BATTLE_PRE
+                    || *p.pendingMode == MODE_BATTLE_RUNTIME);
+            if (startMatchContext)
+                st.phase = MatchBlackWindowState::WAIT_START_BLACK_EXIT;
+            return false;
+        }
+
+        case MatchBlackWindowState::WAIT_START_BLACK_EXIT:
+            // Entry is the first frame the full black itself lifts, not the
+            // first fully bright frame.
+            if (darkening
+                && IsBlackPhase(*p.transitionPhase)
+                && *p.transitionBrightness <= BRIGHTNESS_FULL_BLACK)
+                return false;
+            st.phase = MatchBlackWindowState::ACTIVE;
+            st.postMatchFadeArmed = false;
+            return true;
+
+        default:
+            break;
+        }
+
+        st.phase = MatchBlackWindowState::WAIT_START_BLACK;
+        st.postMatchFadeArmed = false;
+        return false;
     }
 
 } // namespace MelonPrime::BattleFlow

--- a/src/frontend/qt_sdl/MelonPrimeGameRomAddrTable.h
+++ b/src/frontend/qt_sdl/MelonPrimeGameRomAddrTable.h
@@ -63,6 +63,11 @@ namespace MelonPrime {
     X(ADDR, baseAimY,                 BaseAimY,                  0x020E03EEu, 0x020E03AEu, 0x020DE52Eu, 0x020DEDAEu, 0x020DEDCEu, 0x020DEE4Eu, 0x020D7C16u) \
     X(ADDR, baseChosenHunter,         BaseChosenHunter,          0x020CD358u, 0x020CD318u, 0x020CB51Cu, 0x020CBDA4u, 0x020CBDC4u, 0x020CBE44u, 0x020C4B88u) \
     X(ADDR, currentMode,              CurrentMode,               0x020E6B30u, 0x020E6AF0u, 0x020E4A04u, 0x020E54CCu, 0x020E54ECu, 0x020E556Cu, 0x020DE31Au) \
+    X(ADDR, pendingMode,              PendingMode,               0x020E6B28u, 0x020E6AE8u, 0x020E49FCu, 0x020E54C4u, 0x020E54E4u, 0x020E5564u, 0x020DE318u) /* u8; main loop continues the current mode while currentMode == pendingMode */ \
+    X(ADDR, transitionBrightness,     TransitionBrightness,      0x020E6B38u, 0x020E6AF8u, 0x020E4A0Cu, 0x020E54D4u, 0x020E54F4u, 0x020E5574u, 0x020DE320u) /* s32 MASTER_BRIGHT factor; <= -16 is fully black */ \
+    X(ADDR, transitionTargetMode,     TransitionTargetMode,      0x020E6B3Cu, 0x020E6AFCu, 0x020E4A10u, 0x020E54D8u, 0x020E54F8u, 0x020E5578u, 0x020DE324u) /* u8 (brightness +4) */ \
+    X(ADDR, transitionPhase,          TransitionPhase,           0x020E6B3Du, 0x020E6AFDu, 0x020E4A11u, 0x020E54D9u, 0x020E54F9u, 0x020E5579u, 0x020DE325u) /* u8 (brightness +5); 1=fade out 2=full black 3=fade in */ \
+    X(ADDR, transitionType,           TransitionType,            0x020E6B3Eu, 0x020E6AFEu, 0x020E4A12u, 0x020E54DAu, 0x020E54FAu, 0x020E557Au, 0x020DE326u) /* u8 (brightness +6); 1=darken */ \
     X(ADDR, battleFlowState,          BattleFlowState,           0x020E6B48u, 0x020E6B08u, 0x020E4A1Cu, 0x020E54E4u, 0x020E5504u, 0x020E5584u, 0x020DE330u) \
     X(ADDR, inGame,                   InGame,                    0x020F0BB0u, 0x020F0B70u, 0x020EEA70u, 0x020EF530u, 0x020EF550u, 0x020EF5D0u, 0x020E81B4u) \
     X(ADDR, isInAdventure,            IsInAdventure,             0x020E9A3Cu, 0x020E99FCu, 0x020E78FCu, 0x020E83BCu, 0x020E83DCu, 0x020E845Cu, 0x020E11F8u) \

--- a/src/frontend/qt_sdl/MelonPrimeGameRomDetect.cpp
+++ b/src/frontend/qt_sdl/MelonPrimeGameRomDetect.cpp
@@ -131,6 +131,18 @@ namespace MelonPrime {
             m_ptrs.inGame           = GetRamPointer<uint16_t>(ram, m_addrHot.inGame);
             m_ptrs.currentMode      = GetRamPointer<uint8_t>(ram, m_addrHot.currentMode);
             m_ptrs.battleFlowState  = GetRamPointer<uint8_t>(ram, m_addrHot.battleFlowState);
+            // Match black-window state machine inputs. All fixed globals, so
+            // they resolve straight from the ROM address set.
+            m_matchTransitionPtrs.transitionBrightness = GetRamPointer<int32_t>(ram, rom.transitionBrightness);
+            m_matchTransitionPtrs.currentMode          = m_ptrs.currentMode;
+            m_matchTransitionPtrs.pendingMode          = GetRamPointer<uint8_t>(ram, rom.pendingMode);
+            m_matchTransitionPtrs.flowState            = m_ptrs.battleFlowState;
+            m_matchTransitionPtrs.transitionTargetMode = GetRamPointer<uint8_t>(ram, rom.transitionTargetMode);
+            m_matchTransitionPtrs.transitionPhase      = GetRamPointer<uint8_t>(ram, rom.transitionPhase);
+            m_matchTransitionPtrs.transitionType       = GetRamPointer<uint8_t>(ram, rom.transitionType);
+            // A ROM (re)detect re-attaches mid-session; let the window
+            // bootstrap instead of waiting for a pre-match black it missed.
+            m_matchBlackWindow = {};
         }
 
 #ifdef MELONPRIME_DS

--- a/src/frontend/qt_sdl/MelonPrimeLifecycle.cpp
+++ b/src/frontend/qt_sdl/MelonPrimeLifecycle.cpp
@@ -157,6 +157,7 @@ namespace MelonPrime {
         InstanceDiagnostics::LogOwnedStates(
             emuInstance, hookState, patchState, hudState);
         m_flags.packed = 0;
+        m_matchBlackWindow = {};
         // A restarted/reopened ROM begins in menu cursor mode. Supersede any
         // hide/capture request left by the previous match before its next GUI pass.
         isCursorMode = true;
@@ -199,6 +200,7 @@ namespace MelonPrime {
     void MelonPrimeCore::ResetRuntimeStateForBoot()
     {
         m_flags.packed = 0;
+        m_matchBlackWindow = {};
         isCursorMode = true;
         m_threadBridge.ResetCursorPresentationFromEmu();
         m_zoomAimCanZoomCache = {};
@@ -267,6 +269,11 @@ namespace MelonPrime {
 
     void MelonPrimeCore::OnSavestateLoaded()
     {
+        // A savestate can land anywhere, including mid-match: the pre-match
+        // full black this window keys off may already be in the past. Re-arm
+        // the bootstrap so the next frame classifies the loaded state.
+        m_matchBlackWindow = {};
+
 #ifdef MELONPRIME_CUSTOM_HUD
         // Savestates replace emulated ARM9 RAM, but the native-HUD patch
         // tracker is host-owned and is not serialized. Invalidate it on the


### PR DESCRIPTION
The force-software-outside-match path keyed on the ROM's inGame flag, which does not line up with the period the game actually renders a match: it covers lobby/loading frames and drops before the post-match fade completes.

Replace it with the documented match window: true from the frame the pre-match full black lifts until the frame the post-match fade reaches full black. The state machine (WAIT_START_BLACK -> WAIT_START_BLACK_EXIT -> ACTIVE) arms on the post-match fade before testing for full black, so a mode commit on the full-black frame cannot make the end edge be missed.

- Add pendingMode and the four MASTER_BRIGHT transition fields to the ROM address table for all 7 variants.
- Reset the window at every lifecycle transition. OnSavestateLoaded re-arms the bootstrap so a savestate loaded mid-match, where the pre-match black is already in the past, still classifies correctly.
- ShouldForceSoftwareRenderer() no longer consults inGame, so the renderer identity no longer has to be cached for the per-frame edge check.

Hot path: the update takes RAM pointers and reads lazily, keyed on transitionType. With no darken transition running the screen cannot be fully black and the fade cannot arm, so the steady state costs one u8 read per frame instead of seven. The mode/flow context is only read on frames that already tested fully black, and is not re-read once armed.

Verified: MinGW build, SRP/performance and thread-boundary audits. Runtime behavior is untested.