### PR TITLE
Fix SIGSEGV on renderer switch: QThread::terminate() on an already-fi…

### DIFF
--- a/src/frontend/qt_sdl/Platform.cpp
+++ b/src/frontend/qt_sdl/Platform.cpp
@@ -313,7 +313,28 @@ Thread* Thread_Create(std::function<void()> func)
 void Thread_Free(Thread* thread)
 {
     QThread* t = (QThread*) thread;
+    if (!t)
+        return;
+#ifdef MELONPRIME_DS
+    // MELONPRIME_QTHREAD_FREE_NO_TERMINATE_V1
+    // Every Thread_Free() caller signals the thread to return and then calls
+    // Thread_Wait() first, so the thread entry function has already returned by
+    // the time we get here. Qt (6.11 at least) does not clear the stored
+    // pthread handle when a thread finishes, so QThread::terminate() still
+    // issues a real pthread_cancel() against the dead thread. That races the OS
+    // reclaiming the just-exited thread's stack, and pthread_cancel() then
+    // dereferences the unmapped pthread struct and takes the process down --
+    // observed as a SIGSEGV inside pthread_cancel while a renderer switch was
+    // destroying SoftRenderer3D. When the stack has not been reclaimed yet it
+    // merely logs "QThread::start: Thread termination error (No such process)".
+    //
+    // wait() is both sufficient and safe: it returns immediately for a thread
+    // that already finished, and blocks (instead of cancelling) in the case a
+    // future caller forgets its own Thread_Wait().
+    t->wait();
+#else
     t->terminate();
+#endif
     delete t;
 }
 


### PR DESCRIPTION
…nished thread

SoftRenderer3D::StopRenderThread() always calls Thread_Wait() before Thread_Free(), so by the time Thread_Free() runs, the render thread's entry function has already returned. Qt (6.11 at least) does not clear its stored pthread handle when a thread finishes, so QThread::terminate() still issues a real pthread_cancel() against that dead thread. This races the OS reclaiming the just-exited thread's stack: with the stack still mapped it only logs "QThread::start: Thread termination error (No such process)", but once reclaimed, pthread_cancel() dereferences an unmapped pthread struct and crashes the process.

Reproduced with a minimal Qt 6.11 harness (create -> start -> wait -> terminate -> delete, 2000 iterations): the ESRCH warning fires every time, confirming terminate() really does act on the finished thread rather than no-op'ing. Replacing terminate() with another wait() (a no-op for an already -finished thread) eliminates the warning entirely.

This matches a crash reported after switching Metal -> Vulkan: the fault address sat immediately past a just-freed thread's stack region, and the crashing frame was pthread_cancel inside QThread::terminate() inside SoftRenderer3D::~SoftRenderer3D(), reached from GPU::SetRenderer() during EmuThread::updateRenderer(). The bug isn't specific to Metal or Vulkan; it's now easier to hit because the renderer-switch fix in 03481848 routes through an intermediate Software renderer construction/teardown.

Thread_Free() is the only caller of QThread::terminate() in the codebase. Guard the fix with MELONPRIME_DS to leave upstream melonDS behavior alone.