### PR TITLE
fix(hud): settle the editor panel at its target width on BSD hosts

### DIFF
--- a/src/frontend/qt_sdl/MelonPrimeHudEditorFormLayout.cpp
+++ b/src/frontend/qt_sdl/MelonPrimeHudEditorFormLayout.cpp
@@ -2,7 +2,9 @@
 
 #include <algorithm>
 #include <QLabel>
+#include <QLayout>
 #include <QScrollArea>
+#include <QScrollBar>
 #include <QSizePolicy>
 #include <QStyle>
 #include <QWidget>
@@ -66,6 +68,50 @@ void ConstrainWrappedFormLabels(QWidget& root, int maximumWidth)
             if (widget->width() > targetWidth)
                 widget->resize(targetWidth, widget->height());
         }
+    }
+}
+
+int ReservedVerticalScrollBarWidth(const QWidget& root)
+{
+    const QScrollArea* scroll = root.findChild<QScrollArea*>();
+    if (!scroll)
+        return 0;
+    const Qt::ScrollBarPolicy policy = scroll->verticalScrollBarPolicy();
+    // AlwaysOff never takes width; AlwaysOn is already inside sizeHint().
+    if (policy != Qt::ScrollBarAsNeeded)
+        return 0;
+    const QScrollBar* bar = scroll->verticalScrollBar();
+    if (!bar)
+        return 0;
+    return std::max(0, bar->sizeHint().width());
+}
+
+void ConstrainPanelWidth(QWidget& root, int targetWidth, int passes)
+{
+    const int width = targetWidth > 0 ? targetWidth : 1;
+    QScrollArea* scroll = root.findChild<QScrollArea*>();
+    for (int pass = 0; pass < passes; ++pass)
+    {
+        // The viewport can still be wider than the target while the panel is
+        // pinned open by a latched minimum. Bounding the labels against that
+        // transient width would keep them too wide to ever let the panel back
+        // down, so the target width always wins.
+        int constrainWidth = width;
+        if (scroll)
+        {
+            const int viewportWidth = scroll->viewport()->width();
+            if (viewportWidth > 0)
+                constrainWidth = std::min(width, viewportWidth);
+        }
+        ConstrainWrappedFormLabels(root, constrainWidth);
+
+        root.setMinimumWidth(0);
+        if (QLayout* layout = root.layout())
+            layout->activate();
+        if (root.width() != width)
+            root.resize(width, root.height());
+        if (QLayout* layout = root.layout())
+            layout->activate();
     }
 }
 

--- a/src/frontend/qt_sdl/MelonPrimeHudEditorFormLayout.h
+++ b/src/frontend/qt_sdl/MelonPrimeHudEditorFormLayout.h
@@ -20,6 +20,25 @@ QLabel* CreateTranslatedFormLabel(QFormLayout& form, const QString& text);
 // minimum-size hint into hidden horizontal overflow inside QScrollArea.
 void ConstrainWrappedFormLabels(QWidget& root, int maximumWidth);
 
+// Width the panel has to add to its natural content width so the vertical
+// scrollbar its form will eventually show does not eat into the form itself.
+// QScrollArea::sizeHint() only accounts for that scrollbar when the policy is
+// ScrollBarAlwaysOn, so a panel sized from the natural hint alone loses exactly
+// one scrollbar width the moment the content scrolls -- and on hosts with wide
+// default fonts that is enough to squeeze the widest fixed-width row past the
+// viewport edge. Returns 0 when no scroll area is present or its vertical
+// scrollbar is disabled or already priced into the hint.
+int ReservedVerticalScrollBarWidth(const QWidget& root);
+
+// Bound the wrapped labels and settle the panel at exactly targetWidth.
+// Each pass re-bounds the labels against the width the panel is going to have
+// (never a transiently oversized viewport) and clears the latched layout
+// minimum before re-activating, because QLayout::SetDefaultConstraint only ever
+// raises a widget's minimum size: once an unbounded label has pushed that
+// minimum past the window, every later resize() back to the target width is
+// clamped straight back up again.
+void ConstrainPanelWidth(QWidget& root, int targetWidth, int passes);
+
 // True when the widget is rendered with Qt's native Windows style
 // (windowsvista/windows11). This editor's fixed-pixel row budgets (radio
 // pair + color swatch, etc.) were sized with zero slack against that one

--- a/src/frontend/qt_sdl/MelonPrimeHudScreenCppHelpers.inc
+++ b/src/frontend/qt_sdl/MelonPrimeHudScreenCppHelpers.inc
@@ -25,7 +25,11 @@ static void MelonPrimeHud_PositionEditPanel(
     // activating the layout so WrapLongRows can make the final height honest.
     panel->setMinimumWidth(0);
     panel->setMaximumWidth(usableWidth);
-    const int naturalWidth = std::max(panel->sizeHint().width(), panel->minimumSizeHint().width());
+    // The natural hint is measured before the form's vertical scrollbar exists,
+    // so reserve its width here; otherwise the scrollbar takes it back out of
+    // the form the moment the content scrolls.
+    const int naturalWidth = std::max(panel->sizeHint().width(), panel->minimumSizeHint().width())
+        + MelonPrime::HudEditorForm::ReservedVerticalScrollBarWidth(*panel);
     const int desiredWidth = naturalWidth > MelonPrime::HudEditorPanelGeometry::kPreferredWidth
         ? naturalWidth
         : MelonPrime::HudEditorPanelGeometry::kPreferredWidth;
@@ -34,21 +38,7 @@ static void MelonPrimeHud_PositionEditPanel(
         panel->resize(panelW, panel->height());
     if (panel->layout())
         panel->layout()->activate();
-    auto constrainLabelsToViewport = [&]() {
-        if (auto* scroll = panel->findChild<QScrollArea*>())
-        {
-            const int viewportWidth = scroll->viewport()->width() > 0
-                ? scroll->viewport()->width()
-                : panelW;
-            MelonPrime::HudEditorForm::ConstrainWrappedFormLabels(*panel, viewportWidth);
-        }
-    };
-    constrainLabelsToViewport();
-    if (panel->layout())
-        panel->layout()->activate();
-    constrainLabelsToViewport();
-    if (panel->layout())
-        panel->layout()->activate();
+    MelonPrime::HudEditorForm::ConstrainPanelWidth(*panel, panelW, 2);
     if (adjustSize)
     {
         panel->adjustSize();
@@ -56,9 +46,7 @@ static void MelonPrimeHud_PositionEditPanel(
             panel->resize(panelW, panel->height());
         if (panel->layout())
             panel->layout()->activate();
-        constrainLabelsToViewport();
-        if (panel->layout())
-            panel->layout()->activate();
+        MelonPrime::HudEditorForm::ConstrainPanelWidth(*panel, panelW, 1);
     }
 
     const int maxH = std::max(120, bounds.height()

--- a/tools/testing/hud-classic-layout-tests.cpp
+++ b/tools/testing/hud-classic-layout-tests.cpp
@@ -248,12 +248,19 @@ struct CaseSpec
     bool requireWideContent;
 };
 
-bool inside(const QRect& child, const QRect& parent)
+// QFormLayout hands its label and field columns out with integer rounding, so
+// when the viewport lands on exactly the form's minimum width a column can end
+// up a single pixel past the content rect. That one pixel mirrors the slack
+// already granted below for WrapLongRows row-height rounding and for the
+// scroll-area width comparison; anything wider clips a control for real.
+constexpr int kColumnRoundingSlack = 1;
+
+bool inside(const QRect& child, const QRect& parent, int slack = 0)
 {
-    return child.left() >= parent.left()
-        && child.top() >= parent.top()
-        && child.right() <= parent.right()
-        && child.bottom() <= parent.bottom();
+    return child.left() >= parent.left() - slack
+        && child.top() >= parent.top() - slack
+        && child.right() <= parent.right() + slack
+        && child.bottom() <= parent.bottom() + slack;
 }
 
 std::string rectText(const QRect& rect)
@@ -267,8 +274,11 @@ bool checkFixture(ClassicLayoutFixture& fixture, const CaseSpec& spec,
 {
     fixture.root.adjustSize();
     fixture.form->activate();
+    // Mirror MelonPrimeHud_PositionEditPanel: the natural hint is measured
+    // before the vertical scrollbar exists, so the panel has to reserve it.
     const int naturalWidth = std::max(fixture.root.sizeHint().width(),
-                                      fixture.root.minimumSizeHint().width());
+                                      fixture.root.minimumSizeHint().width())
+        + MelonPrime::HudEditorForm::ReservedVerticalScrollBarWidth(fixture.root);
     const int finalWidth = MelonPrime::HudEditorPanelGeometry::FinalWidth(
         spec.windowWidth, naturalWidth);
     const int usableWidth = MelonPrime::HudEditorPanelGeometry::UsableWidth(
@@ -282,11 +292,14 @@ bool checkFixture(ClassicLayoutFixture& fixture, const CaseSpec& spec,
     QApplication::processEvents();
     for (int pass = 0; pass < 3; ++pass)
     {
-        const int viewportWidth = fixture.scroll->viewport()->width();
-        MelonPrime::HudEditorForm::ConstrainWrappedFormLabels(
-            fixture.root, viewportWidth > 0 ? viewportWidth : finalWidth);
+        MelonPrime::HudEditorForm::ConstrainPanelWidth(fixture.root, finalWidth, 1);
         fixture.form->activate();
         QApplication::processEvents();
+        if (fixture.root.width() != finalWidth)
+        {
+            fixture.root.resize(finalWidth, spec.windowHeight);
+            QApplication::processEvents();
+        }
     }
 
     const QRect innerRect = fixture.inner->rect();
@@ -319,8 +332,8 @@ bool checkFixture(ClassicLayoutFixture& fixture, const CaseSpec& spec,
                 + " fieldRect=" + (row.field ? rectText(row.field->geometry()) : "<null>");
             return false;
         }
-        if (!inside(row.label->geometry(), innerRect)
-            || !inside(row.field->geometry(), innerRect))
+        if (!inside(row.label->geometry(), innerRect, kColumnRoundingSlack)
+            || !inside(row.field->geometry(), innerRect, kColumnRoundingSlack))
         {
             failure = "label or field leaves the form viewport label="
                 + row.label->text().toStdString() + " labelRect="


### PR DESCRIPTION
The Classic On-Screen Edit geometry gate failed on all three BSD jobs at "Build BSD release tree". Two independent causes, both reproduced locally under QT_QPA_PLATFORM=offscreen (the plugin BSD/Linux use), where the pre-fix gate fails with byte-identical widths to the FreeBSD/NetBSD logs (T11 1812/2052/2772, T04 426) and passes under the Windows plugin:

- QLayout::SetDefaultConstraint only ever raises a widget's minimum size. An unbreakable title measured before the labels were bounded latched the panel minimum past the window, so every resize() back to the target width was clamped straight back up and the panel stayed wider than the window forever. Clear the latched minimum and re-apply the target width on each constraint pass, and bound the labels against the width the panel is going to have rather than the transiently oversized viewport.

- QScrollArea::sizeHint() excludes the vertical scrollbar while the policy is AsNeeded, so a panel sized from the natural hint alone loses exactly one scrollbar width once the form scrolls -- enough on OpenBSD's metrics to push the widest fixed-width row a pixel past the viewport. Reserve that width up front, and grant the gate's row-inside-content check the same 1px slack it already grants WrapLongRows row-height and scroll-area width rounding.

The sequence lives in ConstrainPanelWidth() so the production position helper and the geometry gate cannot drift apart again.