### PR TITLE
config: default top screen aspect to 16:9

### DIFF
--- a/src/frontend/qt_sdl/Config.cpp
+++ b/src/frontend/qt_sdl/Config.cpp
@@ -564,7 +564,7 @@ namespace Config
         {"ScreenSwap",     1, "Window0.ScreenSwap", true},
         {"ScreenSizing",   0, "Window0.ScreenSizing", true},
         {"IntegerScaling", 1, "Window0.IntegerScaling", true},
-        {"ScreenAspectTop",0, "Window0.ScreenAspectTop", true},
+        {"ScreenAspectTop",1, "Window0.ScreenAspectTop", true},
         {"ScreenAspectBot",0, "Window0.ScreenAspectBot", true},
 
     #ifdef MELONPRIME_DS


### PR DESCRIPTION
Use ScreenAspectTop = 1 as the fallback for new or unset window configurations, which selects the 16:9 top-screen aspect ratio. Existing persisted ScreenAspectTop values remain unchanged.